### PR TITLE
Improve parsing error handling

### DIFF
--- a/recursive_thinking_ai.py
+++ b/recursive_thinking_ai.py
@@ -1,11 +1,12 @@
-import openai
 import os
 from typing import List, Dict
 import json
 import requests
 from datetime import datetime
-import sys
-import time
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 class EnhancedRecursiveThinkingChat:
     def __init__(self, api_key: str = None, model: str = "mistralai/mistral-small-3.1-24b-instruct:free"):
@@ -82,7 +83,10 @@ Respond with just a number between 1 and 5."""
         try:
             rounds = int(''.join(filter(str.isdigit, response)))
             return min(max(rounds, 1), 5)
-        except:
+        except (ValueError, TypeError) as e:
+            logger.error(
+                "Failed to parse thinking rounds from API response: %s", e
+            )
             return 3
     
     def _generate_alternatives(self, base_response: str, prompt: str, num_alternatives: int = 3) -> List[str]:

--- a/tests/test_determine_rounds.py
+++ b/tests/test_determine_rounds.py
@@ -1,0 +1,25 @@
+import os
+import sys
+import logging
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
+
+from recursive_thinking_ai import EnhancedRecursiveThinkingChat  # noqa: E402
+
+
+def test_determine_rounds_invalid_response(monkeypatch, caplog):
+    chat = EnhancedRecursiveThinkingChat(api_key="test")
+    caplog.set_level(logging.ERROR)
+    monkeypatch.setattr(chat, "_call_api", lambda *a, **k: "invalid")
+    result = chat._determine_thinking_rounds("prompt")
+    assert result == 3
+    assert "Failed to parse thinking rounds" in caplog.text
+
+
+def test_determine_rounds_none_response(monkeypatch, caplog):
+    chat = EnhancedRecursiveThinkingChat(api_key="test")
+    caplog.set_level(logging.ERROR)
+    monkeypatch.setattr(chat, "_call_api", lambda *a, **k: None)
+    result = chat._determine_thinking_rounds("prompt")
+    assert result == 3
+    assert "Failed to parse thinking rounds" in caplog.text


### PR DESCRIPTION
## Summary
- add basic logging to CLI module
- log parsing issues in `_determine_thinking_rounds`
- test fallback logic when API returns malformed data

## Testing
- `flake8 tests/test_determine_rounds.py --max-line-length=88`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844fd6f06c083339de0e544cabfca8f