### PR TITLE
Add customizable think-and-respond parameters

### DIFF
--- a/recthink_web.py
+++ b/recthink_web.py
@@ -72,28 +72,13 @@ async def send_message(request: MessageRequest):
             raise HTTPException(status_code=404, detail="Session not found")
         
         chat = chat_instances[request.session_id]
-        
-        # Override class parameters if provided
-        original_thinking_fn = chat._determine_thinking_rounds
-        original_alternatives_fn = chat._generate_alternatives
-        
-        if request.thinking_rounds is not None:
-            # Override the thinking rounds determination
-            chat._determine_thinking_rounds = lambda _: request.thinking_rounds
-        
-        if request.alternatives_per_round is not None:
-            # Store the original function
-            def modified_generate_alternatives(base_response, prompt, num_alternatives=3):
-                return original_alternatives_fn(base_response, prompt, request.alternatives_per_round)
-            
-            chat._generate_alternatives = modified_generate_alternatives
-        
-        # Process the message
-        result = chat.think_and_respond(request.message, verbose=True)
-        
-        # Restore original functions
-        chat._determine_thinking_rounds = original_thinking_fn
-        chat._generate_alternatives = original_alternatives_fn
+
+        result = chat.think_and_respond(
+            request.message,
+            verbose=True,
+            thinking_rounds=request.thinking_rounds,
+            alternatives_per_round=request.alternatives_per_round,
+        )
         
         return {
             "session_id": request.session_id,

--- a/recursive_thinking_ai.py
+++ b/recursive_thinking_ai.py
@@ -160,13 +160,29 @@ Then on a new line, explain your choice in one sentence."""
         
         return current_best, explanation
     
-    def think_and_respond(self, user_input: str, verbose: bool = True) -> Dict:
-        """Process user input with recursive thinking."""
+    def think_and_respond(
+        self,
+        user_input: str,
+        verbose: bool = True,
+        thinking_rounds: int | None = None,
+        alternatives_per_round: int = 3,
+    ) -> Dict:
+        """Process user input with recursive thinking.
+
+        Args:
+            user_input: The message from the user.
+            verbose: Whether to print progress information.
+            thinking_rounds: Number of thinking rounds to run. If ``None``,
+                the model will determine the count automatically.
+            alternatives_per_round: Number of alternative responses generated
+                in each round.
+        """
         print("\n" + "=" * 50)
         print("🤔 RECURSIVE THINKING PROCESS STARTING")
         print("=" * 50)
         
-        thinking_rounds = self._determine_thinking_rounds(user_input)
+        if thinking_rounds is None:
+            thinking_rounds = self._determine_thinking_rounds(user_input)
         
         if verbose:
             print(f"\n🤔 Thinking... ({thinking_rounds} rounds needed)")
@@ -185,7 +201,11 @@ Then on a new line, explain your choice in one sentence."""
                 print(f"\n=== ROUND {round_num}/{thinking_rounds} ===")
             
             # Generate alternatives
-            alternatives = self._generate_alternatives(current_best, user_input)
+            alternatives = self._generate_alternatives(
+                current_best,
+                user_input,
+                alternatives_per_round,
+            )
             
             # Store alternatives in history
             for i, alt in enumerate(alternatives):

--- a/tests/test_api_customization.py
+++ b/tests/test_api_customization.py
@@ -1,0 +1,83 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+import recthink_web  # noqa: E402
+
+
+def setup_session(client):
+    resp = client.post("/api/initialize", json={"api_key": "x", "model": "m"})
+    assert resp.status_code == 200
+    return resp.json()["session_id"]
+
+
+def test_send_message_custom_rounds(monkeypatch):
+    client = TestClient(recthink_web.app)
+    session_id = setup_session(client)
+
+    captured = {}
+
+    def fake_think(
+        msg,
+        verbose=True,
+        thinking_rounds=None,
+        alternatives_per_round=3,
+    ):
+        captured["rounds"] = thinking_rounds
+        captured["alts"] = alternatives_per_round
+        return {
+            "response": "ok",
+            "thinking_rounds": thinking_rounds,
+            "thinking_history": [],
+        }
+
+    recthink_web.chat_instances[session_id].think_and_respond = fake_think
+
+    resp = client.post(
+        "/api/send_message",
+        json={
+            "session_id": session_id,
+            "message": "hi",
+            "thinking_rounds": 2,
+            "alternatives_per_round": 4,
+        },
+    )
+    assert resp.status_code == 200
+    assert captured["rounds"] == 2
+    assert captured["alts"] == 4
+    assert resp.json()["thinking_rounds"] == 2
+
+
+def test_send_message_defaults(monkeypatch):
+    client = TestClient(recthink_web.app)
+    session_id = setup_session(client)
+
+    captured = {}
+
+    def fake_think(
+        msg,
+        verbose=True,
+        thinking_rounds=None,
+        alternatives_per_round=3,
+    ):
+        captured["rounds"] = thinking_rounds
+        captured["alts"] = alternatives_per_round
+        return {
+            "response": "ok",
+            "thinking_rounds": 3,
+            "thinking_history": [],
+        }
+
+    recthink_web.chat_instances[session_id].think_and_respond = fake_think
+
+    resp = client.post(
+        "/api/send_message",
+        json={"session_id": session_id, "message": "hi"},
+    )
+    assert resp.status_code == 200
+    assert captured["rounds"] is None
+    assert captured["alts"] == 3
+    assert resp.json()["thinking_rounds"] == 3


### PR DESCRIPTION
## Summary
- accept `thinking_rounds` and `alternatives_per_round` in `think_and_respond`
- call new parameters from web API
- add tests for API customization

## Testing
- `flake8 recursive_thinking_ai.py recthink_web.py tests/test_api_customization.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844ff0a68d48333b16acff25525a86b