### PR TITLE
Batch alternative generation

### DIFF
--- a/tests/test_generate_alternatives.py
+++ b/tests/test_generate_alternatives.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import json
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from recursive_thinking_ai import EnhancedRecursiveThinkingChat  # noqa: E402
+
+
+def test_generate_alternatives_single_call(monkeypatch):
+    chat = EnhancedRecursiveThinkingChat(api_key="test")
+    calls = []
+
+    def fake_call(messages, temperature=0.7, stream=True):
+        calls.append(messages)
+        return json.dumps({"alternatives": ["a1", "a2"]})
+
+    monkeypatch.setattr(chat, "_call_api", fake_call)
+    alts = chat._generate_alternatives("base", "prompt", num_alternatives=2)
+
+    assert len(calls) == 1
+    assert alts == ["a1", "a2"]


### PR DESCRIPTION
## Summary
- request all alternatives in a single call
- parse JSON output of alternatives
- test the new `_generate_alternatives` implementation

## Testing
- `flake8 recursive_thinking_ai.py tests/test_generate_alternatives.py`
- `pytest -q`
- `npm test --silent -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68450161cf6c833388517c020bdb4eef