### PR TITLE
Implement heuristic scoring for response selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ YES. I tested it with Mistral 3.1 24B and it went from "meh" to "holy crap", esp
 3. For each round:
    - Generates 3 alternative responses
    - Evaluates all responses
-   - Picks the best one
+   - Assigns an overlap score to each option
+   - Combines that score with the model's pick to choose the winner
 4. Final response is the survivor of this AI battle royale
 
 

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,0 +1,24 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from recursive_thinking_ai import EnhancedRecursiveThinkingChat  # noqa: E402
+
+
+def test_score_called(monkeypatch):
+    chat = EnhancedRecursiveThinkingChat(api_key="test")
+    calls = []
+
+    def fake_score(resp, prompt):
+        calls.append(resp)
+        return 0.5
+
+    def fake_call(messages, temperature=0.2, stream=True):
+        return "1\nreason"
+
+    monkeypatch.setattr(chat, "_score_response", fake_score)
+    monkeypatch.setattr(chat, "_call_api", fake_call)
+
+    chat._evaluate_responses("hi there", "a", ["b", "c"])
+    assert len(calls) == 3


### PR DESCRIPTION
## Summary
- score responses based on word overlap
- combine heuristic score with model choice in `_evaluate_responses`
- document scoring in README and code comments
- add unit test for scoring hook

## Testing
- `flake8 --max-line-length=110 --ignore=E302,E501,E305,W293 recursive_thinking_ai.py tests/test_scoring.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68450362365883339fd8bb0625b472e3