### PR TITLE
Add caching to recursive_thinking_ai

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,60 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
+
+import requests  # noqa: E402
+from recursive_thinking_ai import EnhancedRecursiveThinkingChat  # noqa: E402
+
+
+def make_response(text):
+    class Resp:
+        def __init__(self):
+            message = (
+                'data: {"choices": [{"delta": {"content": "' + text + '"}}]}'
+            )
+            self.lines = [message.encode(), b"data: [DONE]"]
+
+        def raise_for_status(self):
+            pass
+
+        def iter_lines(self):
+            for line in self.lines:
+                yield line
+
+        def json(self):
+            return {"choices": [{"message": {"content": text}}]}
+
+    return Resp()
+
+
+def test_cache_hits(monkeypatch):
+    chat = EnhancedRecursiveThinkingChat(api_key="x")
+    calls = []
+
+    def fake_post(*a, **k):
+        calls.append(1)
+        return make_response("hello")
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    messages = [{"role": "user", "content": "hi"}]
+    assert chat._call_api(messages, stream=True) == "hello"
+    assert chat._call_api(messages, stream=True) == "hello"
+    assert len(calls) == 1
+
+
+def test_cache_disabled(monkeypatch):
+    chat = EnhancedRecursiveThinkingChat(api_key="x", caching_enabled=False)
+    calls = []
+
+    def fake_post(*a, **k):
+        calls.append(1)
+        return make_response("hi")
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    messages = [{"role": "user", "content": "hi"}]
+    chat._call_api(messages, stream=True)
+    chat._call_api(messages, stream=True)
+    assert len(calls) == 2


### PR DESCRIPTION
## Summary
- add optional in-memory caching to `EnhancedRecursiveThinkingChat`
- generate cache keys from prompt text and context hash
- store and read results from cache when enabled
- expose `caching_enabled` option
- test cache behaviour

## Testing
- `flake8 tests/test_cache.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845057d969c8333aa893d388a42fe25