### PR TITLE
Add pytest config and core tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,14 @@
   cd frontend && npm start     # frontend UI
   ```
 
+
 ## Tests
-- Place Python tests under a `tests/` directory and run them with `pytest`.
+- Place Python tests under a `tests/` directory.
+- Install dependencies and run `pytest`:
+  ```bash
+  pip install -r requirements.txt
+  pip install pytest flake8
+  pytest
+  ```
 - Frontend tests run with `npm test`.
 - Always run all tests before opening a pull request.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,17 @@ The magic is in:
 
 
 ### Contributing
+
 Found a way to make it even better? PR's welcome!
+
+### Running tests
+Install the requirements and execute pytest:
+```bash
+pip install -r requirements.txt
+pip install pytest flake8
+pytest
+```
+
 
 ### License
 MIT - Go wild with it

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = -ra
+testpaths = tests

--- a/tests/test_main_functions.py
+++ b/tests/test_main_functions.py
@@ -1,0 +1,53 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from recursive_thinking_ai import EnhancedRecursiveThinkingChat  # noqa: E402
+
+
+def test_determine_rounds_valid(monkeypatch):
+    chat = EnhancedRecursiveThinkingChat(api_key="test")
+    monkeypatch.setattr(chat, "_call_api", lambda *a, **k: "4")
+    assert chat._determine_thinking_rounds("prompt") == 4
+
+
+def test_determine_rounds_bounds(monkeypatch):
+    chat = EnhancedRecursiveThinkingChat(api_key="test")
+    monkeypatch.setattr(chat, "_call_api", lambda *a, **k: "7")
+    assert chat._determine_thinking_rounds("prompt") == 5
+
+
+def test_generate_alternatives_fallback(monkeypatch):
+    chat = EnhancedRecursiveThinkingChat(api_key="test")
+    monkeypatch.setattr(chat, "_call_api", lambda *a, **k: "a1\na2\n")
+    alts = chat._generate_alternatives("base", "prompt", num_alternatives=2)
+    assert alts == ["a1", "a2"]
+
+
+def test_think_and_respond_flow(monkeypatch):
+    chat = EnhancedRecursiveThinkingChat(api_key="test")
+    monkeypatch.setattr(chat, "_determine_thinking_rounds", lambda *a, **k: 1)
+    monkeypatch.setattr(chat, "_call_api", lambda *a, **k: "initial")
+    monkeypatch.setattr(
+        chat,
+        "_generate_alternatives",
+        lambda *a, **k: ["alt1"],
+    )
+    monkeypatch.setattr(
+        chat,
+        "_evaluate_responses",
+        lambda *a, **k: ("alt1", "pick alt"),
+    )
+    monkeypatch.setattr(chat, "_trim_conversation_history", lambda: None)
+
+    result = chat.think_and_respond("hi", verbose=False)
+
+    assert result["response"] == "alt1"
+    assert result["thinking_rounds"] == 1
+    assert chat.conversation_history[-1]["content"] == "alt1"
+    assert any(
+        item.get("selected")
+        for item in result["thinking_history"]
+        if item["response"] == "alt1"
+    )


### PR DESCRIPTION
## Summary
- add pytest configuration
- document running tests in README and AGENTS guidelines
- test `_determine_thinking_rounds`, `_generate_alternatives`, and `think_and_respond`

## Testing
- `flake8 tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684506e1a8cc8333abbd6bf74ba17516