### PR TITLE
Integrate tiktoken tokenizer

### DIFF
--- a/recursive_thinking_ai.py
+++ b/recursive_thinking_ai.py
@@ -6,6 +6,10 @@ from collections import OrderedDict
 from typing import List, Dict
 from datetime import datetime
 import requests
+import tiktoken
+from tiktoken import _educational
+import contextlib
+import io
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -44,11 +48,16 @@ class EnhancedRecursiveThinkingChat:
         self.caching_enabled = caching_enabled
         self.cache_size = cache_size
         self.cache: OrderedDict[tuple[str, str], str] = OrderedDict()
+        try:
+            self.tokenizer = tiktoken.get_encoding("cl100k_base")
+        except Exception:
+            buffer = io.StringIO()
+            with contextlib.redirect_stdout(buffer):
+                self.tokenizer = _educational.train_simple_encoding()
 
-    @staticmethod
-    def _estimate_tokens(text: str) -> int:
-        """Return a rough token count for the given text."""
-        return len(text.split())
+    def _estimate_tokens(self, text: str) -> int:
+        """Return the token count for the given text."""
+        return len(self.tokenizer.encode(text))
 
     def _history_token_count(self) -> int:
         return sum(

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pydantic>=1.10.7
 python-dotenv>=1.0.0
 requests>=2.28.0
 openai
+tiktoken


### PR DESCRIPTION
## Summary
- install `tiktoken` dependency
- use tiktoken inside `EnhancedRecursiveThinkingChat`
- fall back to a local educational tokenizer when the standard encoding cannot be loaded

## Testing
- `flake8 recursive_thinking_ai.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68450a7db980833381000f49b59e2d61