### PR TITLE
Add early stopping based on response similarity

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E501,W293

--- a/tests/test_main_functions.py
+++ b/tests/test_main_functions.py
@@ -51,3 +51,39 @@ def test_think_and_respond_flow(monkeypatch):
         for item in result["thinking_history"]
         if item["response"] == "alt1"
     )
+
+
+def test_should_continue_thinking(monkeypatch):
+    chat = EnhancedRecursiveThinkingChat(api_key="test")
+
+    monkeypatch.setattr(chat, "_semantic_similarity", lambda a, b: 0.96)
+    monkeypatch.setattr(chat, "_score_response", lambda resp, prompt: 0.5 if resp == "prev" else 0.51)
+
+    assert not chat._should_continue_thinking("prev", "new", "p")
+
+    monkeypatch.setattr(chat, "_semantic_similarity", lambda a, b: 0.2)
+    monkeypatch.setattr(chat, "_score_response", lambda resp, prompt: 0.2 if resp == "prev" else 0.5)
+
+    assert chat._should_continue_thinking("prev", "new", "p")
+
+
+def test_think_and_respond_early_stop(monkeypatch):
+    chat = EnhancedRecursiveThinkingChat(api_key="test")
+    monkeypatch.setattr(chat, "_determine_thinking_rounds", lambda *a, **k: 3)
+    monkeypatch.setattr(chat, "_call_api", lambda *a, **k: "initial")
+
+    gen_calls = []
+
+    def fake_gen(*a, **k):
+        gen_calls.append(1)
+        return ["alt1"]
+
+    monkeypatch.setattr(chat, "_generate_alternatives", fake_gen)
+    monkeypatch.setattr(chat, "_evaluate_responses", lambda *a, **k: ("initial", "same"))
+    monkeypatch.setattr(chat, "_should_continue_thinking", lambda *a, **k: False)
+    monkeypatch.setattr(chat, "_trim_conversation_history", lambda: None)
+
+    result = chat.think_and_respond("hi", verbose=False)
+
+    assert len(gen_calls) == 1
+    assert len([i for i in result["thinking_history"] if i.get("round") == 1]) == 1


### PR DESCRIPTION
## Summary
- introduce `_should_continue_thinking` for similarity/quality checks
- stop thinking loop early when responses converge
- cover new logic with tests
- configure local flake8 options

## Testing
- `flake8 recursive_thinking_ai.py tests/test_main_functions.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68450e5ebea0833394c05e2ce2651ca4