### PR TITLE
Implement CoRTConfig dataclass support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ pip install -r requirements.txt
 export OPENROUTER_API_KEY="your-key-here"
 python recursive-thinking-ai.py
 ```
-You can also limit the context window by passing `max_context_tokens` when
-creating `EnhancedRecursiveThinkingChat`.
+You can also limit the context window by setting `max_context_tokens` in a
+`CoRTConfig` instance when creating `EnhancedRecursiveThinkingChat`.
 
 ### The Secret Sauce
 The magic is in:

--- a/tests/test_batch_generation.py
+++ b/tests/test_batch_generation.py
@@ -4,11 +4,14 @@ import json
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-from recursive_thinking_ai import EnhancedRecursiveThinkingChat  # noqa: E402
+from recursive_thinking_ai import (  # noqa: E402
+    EnhancedRecursiveThinkingChat,
+    CoRTConfig,
+)
 
 
 def test_batch_generate_and_evaluate_single_call(monkeypatch):
-    chat = EnhancedRecursiveThinkingChat(api_key="test")
+    chat = EnhancedRecursiveThinkingChat(CoRTConfig(api_key="test"))
     calls = []
 
     def fake_call(messages, temperature=0.7, stream=True):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -4,7 +4,10 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
 
 import requests  # noqa: E402
-from recursive_thinking_ai import EnhancedRecursiveThinkingChat  # noqa: E402
+from recursive_thinking_ai import (  # noqa: E402
+    EnhancedRecursiveThinkingChat,
+    CoRTConfig,
+)
 
 
 def make_response(text):
@@ -29,7 +32,7 @@ def make_response(text):
 
 
 def test_cache_hits(monkeypatch):
-    chat = EnhancedRecursiveThinkingChat(api_key="x")
+    chat = EnhancedRecursiveThinkingChat(CoRTConfig(api_key="x"))
     calls = []
 
     def fake_post(*a, **k):
@@ -45,7 +48,9 @@ def test_cache_hits(monkeypatch):
 
 
 def test_cache_disabled(monkeypatch):
-    chat = EnhancedRecursiveThinkingChat(api_key="x", caching_enabled=False)
+    chat = EnhancedRecursiveThinkingChat(
+        CoRTConfig(api_key="x", caching_enabled=False)
+    )
     calls = []
 
     def fake_post(*a, **k):
@@ -63,7 +68,7 @@ def test_cache_disabled(monkeypatch):
 def test_disk_cache_persist(tmp_path, monkeypatch):
     path = tmp_path / "cache.pkl"
     chat = EnhancedRecursiveThinkingChat(
-        api_key="x", disk_cache_path=str(path)
+        CoRTConfig(api_key="x", disk_cache_path=str(path))
     )
 
     monkeypatch.setattr(requests, "post", lambda *a, **k: make_response("hi"))
@@ -78,7 +83,9 @@ def test_disk_cache_persist(tmp_path, monkeypatch):
         return make_response("new")
 
     monkeypatch.setattr(requests, "post", fake_post)
-    chat2 = EnhancedRecursiveThinkingChat(api_key="x", disk_cache_path=str(path))
+    chat2 = EnhancedRecursiveThinkingChat(
+        CoRTConfig(api_key="x", disk_cache_path=str(path))
+    )
 
     assert chat2._call_api(messages, stream=True) == "hi"
     assert not calls
@@ -87,7 +94,7 @@ def test_disk_cache_persist(tmp_path, monkeypatch):
 def test_disk_cache_limit(tmp_path, monkeypatch):
     path = tmp_path / "cache.pkl"
     chat = EnhancedRecursiveThinkingChat(
-        api_key="x", disk_cache_path=str(path), disk_cache_size=1
+        CoRTConfig(api_key="x", disk_cache_path=str(path), disk_cache_size=1)
     )
 
     monkeypatch.setattr(requests, "post", lambda *a, **k: make_response("a"))
@@ -104,7 +111,7 @@ def test_disk_cache_limit(tmp_path, monkeypatch):
 
     monkeypatch.setattr(requests, "post", fake_post)
     chat2 = EnhancedRecursiveThinkingChat(
-        api_key="x", disk_cache_path=str(path), disk_cache_size=1
+        CoRTConfig(api_key="x", disk_cache_path=str(path), disk_cache_size=1)
     )
 
     chat2._call_api([{"role": "user", "content": "a"}], stream=True)

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -6,6 +6,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 from recursive_thinking_ai import (  # noqa: E402
     ContextManager,
     EnhancedRecursiveThinkingChat,
+    CoRTConfig,
 )
 import requests  # noqa: E402
 
@@ -34,7 +35,8 @@ def test_optimize_context_basic():
 
 
 def test_chat_uses_context_manager(monkeypatch):
-    chat = EnhancedRecursiveThinkingChat(api_key="x", max_context_tokens=4)
+    config = CoRTConfig(api_key="x", max_context_tokens=4)
+    chat = EnhancedRecursiveThinkingChat(config)
     chat.tokenizer = DummyTokenizer()
     chat.context_manager = ContextManager(4, chat.tokenizer)
     chat.conversation_history = [

--- a/tests/test_determine_rounds.py
+++ b/tests/test_determine_rounds.py
@@ -4,11 +4,14 @@ import logging
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
 
-from recursive_thinking_ai import EnhancedRecursiveThinkingChat  # noqa: E402
+from recursive_thinking_ai import (  # noqa: E402
+    EnhancedRecursiveThinkingChat,
+    CoRTConfig,
+)
 
 
 def test_determine_rounds_invalid_response(monkeypatch, caplog):
-    chat = EnhancedRecursiveThinkingChat(api_key="test")
+    chat = EnhancedRecursiveThinkingChat(CoRTConfig(api_key="test"))
     caplog.set_level(logging.ERROR)
     monkeypatch.setattr(chat, "_call_api", lambda *a, **k: "invalid")
     result = chat._determine_thinking_rounds("prompt")
@@ -17,7 +20,7 @@ def test_determine_rounds_invalid_response(monkeypatch, caplog):
 
 
 def test_determine_rounds_none_response(monkeypatch, caplog):
-    chat = EnhancedRecursiveThinkingChat(api_key="test")
+    chat = EnhancedRecursiveThinkingChat(CoRTConfig(api_key="test"))
     caplog.set_level(logging.ERROR)
     monkeypatch.setattr(chat, "_call_api", lambda *a, **k: None)
     result = chat._determine_thinking_rounds("prompt")

--- a/tests/test_main_functions.py
+++ b/tests/test_main_functions.py
@@ -7,23 +7,24 @@ import recursive_thinking_ai  # noqa: E402
 from recursive_thinking_ai import (  # noqa: E402
     EnhancedRecursiveThinkingChat,
     ConvergenceTracker,
+    CoRTConfig,
 )
 
 
 def test_determine_rounds_valid(monkeypatch):
-    chat = EnhancedRecursiveThinkingChat(api_key="test")
+    chat = EnhancedRecursiveThinkingChat(CoRTConfig(api_key="test"))
     monkeypatch.setattr(chat, "_call_api", lambda *a, **k: "4")
     assert chat._determine_thinking_rounds("prompt") == 4
 
 
 def test_determine_rounds_bounds(monkeypatch):
-    chat = EnhancedRecursiveThinkingChat(api_key="test")
+    chat = EnhancedRecursiveThinkingChat(CoRTConfig(api_key="test"))
     monkeypatch.setattr(chat, "_call_api", lambda *a, **k: "7")
     assert chat._determine_thinking_rounds("prompt") == 5
 
 
 def test_think_and_respond_flow(monkeypatch):
-    chat = EnhancedRecursiveThinkingChat(api_key="test")
+    chat = EnhancedRecursiveThinkingChat(CoRTConfig(api_key="test"))
     monkeypatch.setattr(chat, "_determine_thinking_rounds", lambda *a, **k: 1)
     monkeypatch.setattr(chat, "_call_api", lambda *a, **k: "initial")
     monkeypatch.setattr(
@@ -90,7 +91,7 @@ def test_convergence_tracker_oscillation():
 
 
 def test_think_and_respond_early_stop(monkeypatch):
-    chat = EnhancedRecursiveThinkingChat(api_key="test")
+    chat = EnhancedRecursiveThinkingChat(CoRTConfig(api_key="test"))
     monkeypatch.setattr(chat, "_determine_thinking_rounds", lambda *a, **k: 3)
     monkeypatch.setattr(chat, "_call_api", lambda *a, **k: "initial")
 

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -4,11 +4,14 @@ import json
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-from recursive_thinking_ai import EnhancedRecursiveThinkingChat  # noqa: E402
+from recursive_thinking_ai import (  # noqa: E402
+    EnhancedRecursiveThinkingChat,
+    CoRTConfig,
+)
 
 
 def test_score_called(monkeypatch):
-    chat = EnhancedRecursiveThinkingChat(api_key="test")
+    chat = EnhancedRecursiveThinkingChat(CoRTConfig(api_key="test"))
     calls = []
 
     def fake_score(resp, prompt):
@@ -32,7 +35,7 @@ def test_score_called(monkeypatch):
 
 
 def test_quality_assessor_keys():
-    chat = EnhancedRecursiveThinkingChat(api_key="x")
+    chat = EnhancedRecursiveThinkingChat(CoRTConfig(api_key="x"))
     metrics = chat.quality_assessor.comprehensive_score("resp", "prompt")
     for key in ["relevance", "completeness", "clarity", "accuracy", "overall"]:
         assert key in metrics


### PR DESCRIPTION
## Summary
- add `CoRTConfig` dataclass for configuration
- refactor `EnhancedRecursiveThinkingChat` to take `CoRTConfig`
- update CLI and FastAPI server to use the new config object
- adjust README usage notes
- update tests for the new initialization

## Testing
- `flake8 recursive_thinking_ai.py recthink_web.py tests/test_main_functions.py tests/test_context_manager.py tests/test_batch_generation.py tests/test_determine_rounds.py tests/test_cache.py tests/test_scoring.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68451f2cf5208333a2621a9246e43460