### PR TITLE
Add environment-based settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,10 @@ Mistral 3.1 24B non CoRT
 ## Try it yourself
 ```python
 pip install -r requirements.txt
+# Option 1: export your API key
 export OPENROUTER_API_KEY="your-key-here"
+# Option 2: place it in a `.env` file
+# OPENROUTER_API_KEY=your-key-here
 python recursive-thinking-ai.py
 ```
 You can also limit the context window by setting `max_context_tokens` in a

--- a/config/settings.py
+++ b/config/settings.py
@@ -1,0 +1,15 @@
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Application settings loaded from environment variables."""
+
+    openrouter_api_key: str | None = None
+    model: str = "mistralai/mistral-small-3.1-24b-instruct:free"
+
+    class Config:
+        env_file = ".env"
+        case_sensitive = False
+
+
+settings = Settings()

--- a/recthink_web.py
+++ b/recthink_web.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI, WebSocket, HTTPException, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
+from config.settings import settings
 import uvicorn
 import json
 import os
@@ -33,8 +34,8 @@ chat_instances = {}
 
 # Pydantic models for request/response validation
 class ChatConfig(BaseModel):
-    api_key: str
-    model: str = "mistralai/mistral-small-3.1-24b-instruct:free"
+    api_key: str | None = settings.openrouter_api_key
+    model: str = settings.model
 
 
 class MessageRequest(BaseModel):

--- a/recursive_thinking_ai.py
+++ b/recursive_thinking_ai.py
@@ -18,6 +18,7 @@ import time
 import structlog
 import asyncio
 import aiohttp
+from config.settings import settings
 
 logging.basicConfig(level=logging.INFO)
 structlog.configure(logger_factory=structlog.stdlib.LoggerFactory())
@@ -36,8 +37,10 @@ class ThinkingResult:
 class CoRTConfig:
     """Configuration for :class:`EnhancedRecursiveThinkingChat`."""
 
-    api_key: str | None = None
-    model: str = "mistralai/mistral-small-3.1-24b-instruct:free"
+    api_key: str | None = field(
+        default_factory=lambda: settings.openrouter_api_key
+    )
+    model: str = field(default_factory=lambda: settings.model)
     max_context_tokens: int = 2000
     caching_enabled: bool = True
     cache_size: int = 128
@@ -801,13 +804,12 @@ def main():
     print("🤖 Enhanced Recursive Thinking Chat")
     print("=" * 50)
     
-    # Get API key
-    api_key = input("Enter your OpenRouter API key (or press Enter to use env variable): ").strip()
+    api_key = settings.openrouter_api_key
     if not api_key:
-        api_key = os.getenv("OPENROUTER_API_KEY")
-        if not api_key:
-            print("Error: No API key provided and OPENROUTER_API_KEY not found in environment")
-            return
+        print(
+            "Error: OPENROUTER_API_KEY not set. Please export it or add to .env"
+        )
+        return
     
     # Initialize chat using configuration dataclass
     config = CoRTConfig(api_key=api_key)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ fastapi>=0.95.0
 uvicorn[standard]>=0.21.0
 websockets>=11.0.3
 pydantic>=1.10.7
+pydantic-settings>=2.0.3
 python-dotenv>=1.0.0
 requests>=2.28.0
 openai


### PR DESCRIPTION
## Summary
- add pydantic settings module
- default to new settings in CoRTConfig
- default to new settings in recthink_web ChatConfig
- remove API key prompt and document environment variables
- install pydantic-settings

## Testing
- `flake8 recursive_thinking_ai.py recthink_web.py config/settings.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68452d5d47fc8333872c4369cdff9e4f