### PR TITLE
Add API error handling

### DIFF
--- a/exceptions.py
+++ b/exceptions.py
@@ -1,0 +1,10 @@
+class APIError(Exception):
+    """Base exception for API related errors."""
+
+
+class RateLimitError(APIError):
+    """Raised when the API rate limit is exceeded."""
+
+
+class TokenLimitError(APIError):
+    """Raised when the request exceeds the allowed token limit."""

--- a/tests/test_async_chat.py
+++ b/tests/test_async_chat.py
@@ -13,6 +13,7 @@ from recursive_thinking_ai import (  # noqa: E402
 class DummyResponse:
     def __init__(self, text):
         self.text = text
+        self.status = 200
 
     async def __aenter__(self):
         return self

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -17,6 +17,7 @@ def make_response(text):
                 'data: {"choices": [{"delta": {"content": "' + text + '"}}]}'
             )
             self.lines = [message.encode(), b"data: [DONE]"]
+            self.status_code = 200
 
         def raise_for_status(self):
             pass

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -52,6 +52,9 @@ def test_chat_uses_context_manager(monkeypatch):
             def raise_for_status(self):
                 pass
 
+            def __init__(self):
+                self.status_code = 200
+
             def iter_lines(self):
                 line = (
                     'data: {"choices": [{"delta": {"content": "' + text + '"}}]}'

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,56 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import requests  # noqa: E402
+import pytest  # noqa: E402
+
+from recursive_thinking_ai import (  # noqa: E402
+    EnhancedRecursiveThinkingChat,
+    CoRTConfig,
+)
+from exceptions import APIError, RateLimitError, TokenLimitError  # noqa: E402
+
+
+class DummyResp:
+    def __init__(self, status, data="err"):
+        self.status_code = status
+        self.data = data
+
+    def iter_lines(self):
+        yield b"data: [DONE]"
+
+    def json(self):
+        return {"error": self.data}
+
+
+def test_rate_limit_error(monkeypatch):
+    chat = EnhancedRecursiveThinkingChat(CoRTConfig(api_key="x"))
+
+    monkeypatch.setattr(requests, "post", lambda *a, **k: DummyResp(429))
+
+    with pytest.raises(RateLimitError):
+        chat._call_api([{"role": "user", "content": "hi"}], stream=False)
+
+
+def test_token_limit_error(monkeypatch):
+    chat = EnhancedRecursiveThinkingChat(CoRTConfig(api_key="x"))
+
+    monkeypatch.setattr(requests, "post", lambda *a, **k: DummyResp(400, "token exceeded"))
+
+    with pytest.raises(TokenLimitError):
+        chat._call_api([{"role": "user", "content": "hi"}], stream=False)
+
+
+def test_circuit_breaker(monkeypatch):
+    chat = EnhancedRecursiveThinkingChat(CoRTConfig(api_key="x", max_retries=2))
+
+    monkeypatch.setattr(requests, "post", lambda *a, **k: DummyResp(500))
+
+    with pytest.raises(APIError):
+        chat._call_api([{"role": "user", "content": "hi"}], stream=False)
+    assert chat.circuit_open
+
+    with pytest.raises(APIError):
+        chat._call_api([{"role": "user", "content": "again"}], stream=False)


### PR DESCRIPTION
## Summary
- introduce exceptions for API errors
- handle rate limiting, token limits, and circuit breaker
- add jittered exponential backoff for API retries
- expand unit tests for new behaviour

## Testing
- `flake8 exceptions.py recursive_thinking_ai.py tests/test_async_chat.py tests/test_cache.py tests/test_context_manager.py tests/test_exceptions.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68452eb573208333a6d1941ad425aae4