### PR TITLE
Implement async alternative streaming

### DIFF
--- a/tests/test_main_functions.py
+++ b/tests/test_main_functions.py
@@ -90,6 +90,17 @@ def test_convergence_tracker_oscillation():
     assert reason == "oscillation"
 
 
+def test_convergence_tracker_update():
+    tracker = ConvergenceTracker(
+        lambda a, b: 0.96,
+        lambda resp, prompt: 0.5 if resp == "prev" else 0.51,
+    )
+    tracker.add("prev", "p")
+    cont, reason = tracker.update("new", "p")
+    assert not cont
+    assert reason == "converged"
+
+
 def test_think_and_respond_early_stop(monkeypatch):
     chat = EnhancedRecursiveThinkingChat(CoRTConfig(api_key="test"))
     monkeypatch.setattr(chat, "_determine_thinking_rounds", lambda *a, **k: 3)


### PR DESCRIPTION
## Summary
- redesign alternative generation to stream asynchronously
- evaluate convergence after each alternative
- add update helper to `ConvergenceTracker`
- test early stopping behavior

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68453276105c8333a475918af446c3a8