### PR TITLE
Add asynchronous API calls with aiohttp

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from core.chat import CoRTConfig, EnhancedRecursiveThinkingChat
+from core.chat import CoRTConfig, AsyncEnhancedRecursiveThinkingChat
 from config.settings import settings
 
 
-def main() -> None:
+async def main() -> None:
     print("🤖 Enhanced Recursive Thinking Chat")
     print("=" * 50)
 
@@ -14,7 +14,7 @@ def main() -> None:
         return
 
     config = CoRTConfig(api_key=api_key)
-    chat = EnhancedRecursiveThinkingChat(config)
+    chat = AsyncEnhancedRecursiveThinkingChat(config)
 
     print("\nChat initialized! Type 'exit' to quit, 'save' to save conversation.")
     print("The AI will think recursively before each response.\n")
@@ -32,7 +32,7 @@ def main() -> None:
         if not user_input:
             continue
 
-        result = chat.think_and_respond(user_input)
+        result = await chat.think_and_respond(user_input)
         print(f"\n🤖 AI FINAL RESPONSE: {result.response}\n")
         print("\n--- COMPLETE THINKING PROCESS ---")
         for item in result.thinking_history:
@@ -51,7 +51,10 @@ def main() -> None:
         if save_full == "y":
             chat.save_full_log()
     print("Goodbye! 👋")
+    await chat.close()
 
 
 if __name__ == "__main__":
-    main()
+    import asyncio
+
+    asyncio.run(main())

--- a/tests/test_api_customization.py
+++ b/tests/test_api_customization.py
@@ -20,7 +20,7 @@ def test_send_message_custom_rounds(monkeypatch):
 
     captured = {}
 
-    def fake_think(
+    async def fake_think(
         msg,
         verbose=True,
         thinking_rounds=None,
@@ -57,7 +57,7 @@ def test_send_message_defaults(monkeypatch):
 
     captured = {}
 
-    def fake_think(
+    async def fake_think(
         msg,
         verbose=True,
         thinking_rounds=None,


### PR DESCRIPTION
## Summary
- support aiohttp sessions and semaphores in openrouter API wrapper
- implement AsyncEnhancedRecursiveThinkingChat with async `think_and_respond`
- update web API and CLI to use async chat methods
- adjust tests for asyncio execution

## Testing
- `flake8 api/openrouter.py cli/main.py core/chat.py recthink_web.py tests/test_api_customization.py tests/test_async_chat.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845a2727a8083338e62aa0f7462bc5d