### PR TITLE
Add metrics recorder with tests

### DIFF
--- a/monitoring/__init__.py
+++ b/monitoring/__init__.py
@@ -1,0 +1,5 @@
+"""Monitoring utilities for runtime metrics."""
+
+from .metrics import MetricsRecorder, RunMetrics, summarize_recent_runs
+
+__all__ = ["MetricsRecorder", "RunMetrics", "summarize_recent_runs"]

--- a/monitoring/metrics.py
+++ b/monitoring/metrics.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict, field
+from datetime import datetime
+from typing import List, Dict
+
+import structlog
+
+
+@dataclass
+class RunMetrics:
+    processing_time: float
+    token_usage: int
+    num_rounds: int
+    convergence_reason: str
+    timestamp: datetime = field(default_factory=datetime.utcnow)
+
+
+class MetricsRecorder:
+    """Record and summarize run metrics."""
+
+    def __init__(self) -> None:
+        self.runs: List[RunMetrics] = []
+        self.logger = structlog.get_logger(__name__)
+
+    def record_run(
+        self,
+        processing_time: float,
+        token_usage: int,
+        num_rounds: int,
+        convergence_reason: str,
+    ) -> None:
+        run = RunMetrics(
+            processing_time=processing_time,
+            token_usage=token_usage,
+            num_rounds=num_rounds,
+            convergence_reason=convergence_reason,
+        )
+        self.runs.append(run)
+        self.logger.info("run_metrics", **asdict(run))
+
+    def summary(self, last_n: int = 5) -> Dict[str, float | str | int]:
+        recent = self.runs[-last_n:]
+        if not recent:
+            return {}
+        avg_time = sum(r.processing_time for r in recent) / len(recent)
+        avg_tokens = sum(r.token_usage for r in recent) / len(recent)
+        avg_rounds = sum(r.num_rounds for r in recent) / len(recent)
+        reasons: Dict[str, int] = {}
+        for r in recent:
+            reasons[r.convergence_reason] = reasons.get(r.convergence_reason, 0) + 1
+        most_common = max(reasons, key=reasons.get)
+        return {
+            "runs": len(recent),
+            "avg_processing_time": avg_time,
+            "avg_token_usage": avg_tokens,
+            "avg_rounds": avg_rounds,
+            "most_common_reason": most_common,
+        }
+
+
+def summarize_recent_runs(recorder: MetricsRecorder, last_n: int = 5) -> str:
+    data = recorder.summary(last_n)
+    if not data:
+        return "No runs recorded."
+    return (
+        f"Last {data['runs']} runs - Avg time: {data['avg_processing_time']:.2f}s, "
+        f"Avg tokens: {data['avg_token_usage']:.0f}, Avg rounds: {data['avg_rounds']:.2f}, "
+        f"Most common reason: {data['most_common_reason']}"
+    )

--- a/tests/test_metrics_recorder.py
+++ b/tests/test_metrics_recorder.py
@@ -1,0 +1,47 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
+
+from core.chat import EnhancedRecursiveThinkingChat, CoRTConfig  # noqa: E402
+from monitoring import MetricsRecorder  # noqa: E402
+
+
+def test_metrics_recording(monkeypatch):
+    chat = EnhancedRecursiveThinkingChat(CoRTConfig(api_key="x"))
+    monkeypatch.setattr(chat, "_determine_thinking_rounds", lambda *a, **k: 1)
+    monkeypatch.setattr(chat, "_trim_conversation_history", lambda: None)
+
+    def fake_call_api(messages, *a, **k):
+        chat.full_thinking_log.append({"messages": messages, "response": "resp"})
+        return "resp"
+
+    monkeypatch.setattr(chat, "_call_api", fake_call_api)
+    monkeypatch.setattr(
+        chat,
+        "_batch_generate_and_evaluate",
+        lambda *a, **k: ("resp", ["resp"], "same"),
+    )
+    monkeypatch.setattr(chat.quality_assessor, "comprehensive_score", lambda *a, **k: {"overall": 1})
+    monkeypatch.setattr(chat, "_semantic_similarity", lambda *a, **k: 0.0)
+
+    recorder = MetricsRecorder()
+    chat.think_and_respond("hi", verbose=False, metrics_recorder=recorder)
+    assert len(recorder.runs) == 1
+    run = recorder.runs[0]
+    assert run.processing_time >= 0
+    assert run.token_usage > 0
+    assert run.num_rounds == 1
+    assert run.convergence_reason
+
+    summary = recorder.summary()
+    assert summary["runs"] == 1
+    assert "avg_processing_time" in summary
+
+
+def test_summary_helper():
+    rec = MetricsRecorder()
+    rec.record_run(1.0, 10, 2, "converged")
+    rec.record_run(2.0, 20, 3, "converged")
+    text = rec.summary()
+    assert text["runs"] == 2


### PR DESCRIPTION
## Summary
- implement `MetricsRecorder` to log processing time, token usage, number of rounds and convergence reason
- log metrics via structlog and summarise recent runs
- integrate recorder with chat classes
- test metrics recorder behaviour

## Testing
- `flake8 monitoring/ tests/test_metrics_recorder.py core/chat.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845a6deaa9c833381f1cd72d0744deb