### PR TITLE
Add environment-based config

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ pip install -r requirements.txt
 export OPENROUTER_API_KEY="your-key-here"
 # Option 2: place it in a `.env` file
 # OPENROUTER_API_KEY=your-key-here
+# Select environment (development|staging|production)
+export APP_ENV=development
+# Optional overrides
+# API_BASE_URL=https://api.example.com
+# WS_BASE_URL=wss://api.example.com
 python recursive-thinking-ai.py
 ```
 You can also limit the context window by setting `max_context_tokens` in a

--- a/api/openrouter.py
+++ b/api/openrouter.py
@@ -5,9 +5,10 @@ import aiohttp
 from typing import Optional
 
 from exceptions import APIError, RateLimitError, TokenLimitError
+from config import settings
 
-BASE_URL = "https://openrouter.ai/api/v1/chat/completions"
-EMBED_URL = "https://openrouter.ai/api/v1/embeddings"
+BASE_URL = settings.api_base_url
+EMBED_URL = settings.embed_url
 
 
 def _handle_response(response):

--- a/cli/main.py
+++ b/cli/main.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from core.chat import CoRTConfig, AsyncEnhancedRecursiveThinkingChat
-from config.settings import settings
+from config import settings
 
 
 async def main() -> None:

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,0 +1,57 @@
+"""Environment-aware settings for RecThink."""
+
+from __future__ import annotations
+
+import os
+
+from .settings import Settings
+
+
+class Development(Settings):
+    """Default development configuration."""
+
+    pass
+
+
+class Staging(Settings):
+    """Settings for a staging deployment."""
+
+    api_base_url: str = "https://staging.example.com/api"
+    frontend_url: str = "https://staging.example.com"
+    ws_base_url: str = "wss://staging.example.com"
+
+
+class Production(Settings):
+    """Settings for production deployments."""
+
+    api_base_url: str = "https://api.example.com"
+    frontend_url: str = "https://example.com"
+    ws_base_url: str = "wss://example.com"
+
+
+_env_map = {
+    "development": Development,
+    "staging": Staging,
+    "production": Production,
+}
+
+
+def get_settings() -> Settings:
+    """Return settings based on ``APP_ENV``."""
+
+    env = os.getenv("APP_ENV", "development").lower()
+    cls = _env_map.get(env, Development)
+    return cls()
+
+
+settings = get_settings()
+
+
+__all__ = [
+    "Development",
+    "Staging",
+    "Production",
+    "settings",
+    "get_settings",
+]
+

--- a/config/settings.py
+++ b/config/settings.py
@@ -6,10 +6,13 @@ class Settings(BaseSettings):
 
     openrouter_api_key: str | None = None
     model: str = "mistralai/mistral-small-3.1-24b-instruct:free"
+    api_base_url: str = "https://openrouter.ai/api/v1/chat/completions"
+    embed_url: str = "https://openrouter.ai/api/v1/embeddings"
+    frontend_url: str = "http://localhost:3000"
+    ws_base_url: str = "ws://localhost:8000"
 
     class Config:
         env_file = ".env"
         case_sensitive = False
 
 
-settings = Settings()

--- a/core/chat.py
+++ b/core/chat.py
@@ -22,7 +22,7 @@ import tiktoken
 from tiktoken import _educational
 
 from api import openrouter
-from config.settings import settings
+from config import settings
 from core.context import ContextManager
 from core.recursion import ConvergenceTracker, QualityAssessor
 from exceptions import APIError, RateLimitError, TokenLimitError
@@ -68,7 +68,7 @@ class EnhancedRecursiveThinkingChat:
         self.max_context_tokens = config.max_context_tokens
         self.headers = {
             "Authorization": f"Bearer {self.api_key}",
-            "HTTP-Referer": "http://localhost:3000",
+            "HTTP-Referer": settings.frontend_url,
             "X-Title": "Recursive Thinking Chat",
             "Content-Type": "application/json",
         }

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,5 +1,5 @@
 // API client for RecThink
-const API_BASE_URL = 'http://localhost:8000/api';
+const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:8000/api';
 
 export const initializeChat = async (apiKey, model) => {
   const response = await fetch(`${API_BASE_URL}/initialize`, {
@@ -81,6 +81,7 @@ export const deleteSession = async (sessionId) => {
 };
 
 export const createWebSocketConnection = (sessionId) => {
-  const ws = new WebSocket(`ws://localhost:8000/ws/${sessionId}`);
+  const wsBase = process.env.REACT_APP_WS_BASE_URL || 'ws://localhost:8000';
+  const ws = new WebSocket(`${wsBase}/ws/${sessionId}`);
   return ws;
 };

--- a/recthink_web.py
+++ b/recthink_web.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI, WebSocket, HTTPException, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
-from config.settings import settings
+from config import settings
 import uvicorn
 import json
 import os
@@ -218,7 +218,7 @@ async def websocket_endpoint(websocket: WebSocket, session_id: str):
 # Serve the React app
 @app.get("/")
 async def root():
-    return {"message": "RecThink API is running. Frontend available at http://localhost:3000"}
+    return {"message": f"RecThink API is running. Frontend available at {settings.frontend_url}"}
 
 if __name__ == "__main__":
     uvicorn.run("recthink_web:app", host="0.0.0.0", port=8000, reload=True)


### PR DESCRIPTION
## Summary
- configure settings via `APP_ENV`
- expose Development, Staging and Production modes
- make OpenRouter URLs and frontend URL configurable
- read new environment vars in frontend
- document environment config in README

## Testing
- `flake8 config/__init__.py config/settings.py api/openrouter.py core/chat.py recthink_web.py cli/main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845a9ddaebc83339a34cb2483a834c0