### PR TITLE
Implement modular chat engine

### DIFF
--- a/core/cache_provider.py
+++ b/core/cache_provider.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from collections import OrderedDict
+
+from core.interfaces import CacheProvider
+
+
+class InMemoryCache(CacheProvider):
+    """Simple LRU in-memory cache."""
+
+    def __init__(self, max_size: int = 128) -> None:
+        self.max_size = max_size
+        self.store: OrderedDict[str, str] = OrderedDict()
+
+    def get(self, key: str) -> str | None:
+        if key in self.store:
+            self.store.move_to_end(key)
+            return self.store[key]
+        return None
+
+    def set(self, key: str, value: str) -> None:
+        self.store[key] = value
+        self.store.move_to_end(key)
+        if len(self.store) > self.max_size:
+            self.store.popitem(last=False)

--- a/core/chat_engine.py
+++ b/core/chat_engine.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+import tiktoken
+
+from core.interfaces import LLMProvider, CacheProvider, QualityEvaluator
+from core.context_manager import ContextManager
+from core.resilience import RetryState, with_retry
+
+
+def _cache_key(messages: List[Dict[str, str]]) -> str:
+    raw = json.dumps(messages, sort_keys=True)
+    return hashlib.md5(raw.encode("utf-8")).hexdigest()
+
+
+@dataclass
+class ReasonerState:
+    best_response: str = ""
+    best_score: float = 0.0
+    history: List[Dict[str, str]] = field(default_factory=list)
+
+
+class ChatEngine:
+    """Reasoning engine using dependency injection."""
+
+    def __init__(
+        self,
+        llm: LLMProvider,
+        cache: CacheProvider,
+        evaluator: QualityEvaluator,
+        *,
+        max_tokens: int = 2000,
+    ) -> None:
+        self.llm = llm
+        self.cache = cache
+        self.evaluator = evaluator
+        try:
+            self.tokenizer = tiktoken.get_encoding("cl100k_base")
+        except Exception:
+            from tiktoken import _educational
+
+            self.tokenizer = _educational.train_simple_encoding()
+        self.context = ContextManager(max_tokens, self.tokenizer)
+        self.state = ReasonerState()
+
+    async def _call_llm(self, messages: List[Dict[str, str]], temperature: float = 0.7) -> str:
+        key = _cache_key(messages)
+        cached = self.cache.get(key)
+        if cached is not None:
+            return cached
+
+        async def coro():
+            return await self.llm.chat(messages, temperature=temperature)
+
+        resp = await with_retry(coro, RetryState())
+        self.cache.set(key, resp)
+        return resp
+
+    async def think(self, prompt: str, *, max_rounds: int = 3) -> str:
+        messages = [{"role": "user", "content": prompt}]
+        best = await self._call_llm(messages)
+        self.state.best_response = best
+        self.state.best_score = self.evaluator.score(best, prompt)
+        self.state.history.append({"round": 0, "response": best})
+        for round_no in range(1, max_rounds + 1):
+            alternatives = 1 if self.state.best_score > 0.9 else 3
+            tasks = []
+            for i in range(alternatives):
+                alt_prompt = f"Alternative {i+1}: {prompt}"
+                msgs = [{"role": "user", "content": alt_prompt}]
+                tasks.append(asyncio.create_task(self._call_llm(msgs)))
+            done, _ = await asyncio.wait(tasks, timeout=10)
+            if not done:
+                break
+            chosen = None
+            for task in done:
+                text = task.result()
+                score = self.evaluator.score(text, prompt)
+                self.state.history.append({"round": round_no, "response": text})
+                if score > self.state.best_score:
+                    self.state.best_score = score
+                    self.state.best_response = text
+                    chosen = text
+            if chosen is None:
+                break
+        return self.state.best_response

--- a/core/context_manager.py
+++ b/core/context_manager.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Callable, Dict, List
+
+
+class ContextManager:
+    """Advanced context manager preserving important messages."""
+
+    def __init__(
+        self,
+        max_tokens: int,
+        tokenizer,
+        summarizer: Callable[[List[Dict[str, str]]], str] | None = None,
+    ) -> None:
+        self.max_tokens = max_tokens
+        self.tokenizer = tokenizer
+        self.summarizer = summarizer
+
+    def _count(self, text: str) -> int:
+        return len(self.tokenizer.encode(text))
+
+    def optimize(self, messages: List[Dict[str, str]]) -> List[Dict[str, str]]:
+        if not messages:
+            return []
+
+        system_msgs = [m for m in messages if m.get("role") == "system"]
+        convo = [m for m in messages if m.get("role") != "system"]
+
+        def msg_tokens(msg: Dict[str, str]) -> int:
+            return self._count(msg.get("content", ""))
+
+        total = sum(msg_tokens(m) for m in messages)
+        if total <= self.max_tokens:
+            return list(messages)
+
+        preserved = list(system_msgs)
+        recent = []
+        token_total = sum(msg_tokens(m) for m in preserved)
+        for msg in reversed(convo):
+            t = msg_tokens(msg)
+            if token_total + t > self.max_tokens:
+                break
+            recent.insert(0, msg)
+            token_total += t
+        remaining = [m for m in convo if m not in recent]
+        summary = ""
+        if remaining and self.summarizer is not None:
+            summary = self.summarizer(remaining)
+            token_total += self._count(summary)
+        if token_total > self.max_tokens:
+            while recent and token_total > self.max_tokens:
+                removed = recent.pop(0)
+                token_total -= msg_tokens(removed)
+        if summary:
+            preserved.append({"role": "system", "content": summary})
+        return preserved + recent

--- a/core/interfaces.py
+++ b/core/interfaces.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, List, Dict
+
+
+@dataclass
+class Message:
+    role: str
+    content: str
+
+
+class LLMProvider(Protocol):
+    """Interface for large language model providers."""
+
+    async def chat(self, messages: List[Dict[str, str]], *, temperature: float = 0.7) -> str:
+        """Send chat completion request and return response text."""
+
+
+class CacheProvider(Protocol):
+    """Interface for caching backend."""
+
+    def get(self, key: str) -> str | None:
+        """Retrieve value from cache."""
+
+    def set(self, key: str, value: str) -> None:
+        """Store value in cache."""
+
+
+class QualityEvaluator(Protocol):
+    """Interface for scoring model responses."""
+
+    def score(self, response: str, prompt: str) -> float:
+        """Return quality score between 0 and 1."""

--- a/core/llm_provider.py
+++ b/core/llm_provider.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import List, Dict
+
+from api import openrouter
+from config import settings
+from core.interfaces import LLMProvider
+
+
+class OpenRouterProvider(LLMProvider):
+    """LLM provider using the OpenRouter API."""
+
+    def __init__(self, api_key: str | None = None, model: str | None = None) -> None:
+        self.api_key = api_key or settings.openrouter_api_key
+        self.model = model or settings.model
+        self.headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "HTTP-Referer": settings.frontend_url,
+            "X-Title": "Recursive Thinking Chat",
+            "Content-Type": "application/json",
+        }
+
+    async def chat(self, messages: List[Dict[str, str]], *, temperature: float = 0.7) -> str:
+        return await openrouter.async_chat_completion(
+            self.headers, messages, self.model, temperature=temperature
+        )

--- a/core/quality_evaluator.py
+++ b/core/quality_evaluator.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import Callable
+
+from core.interfaces import QualityEvaluator
+from core.recursion import QualityAssessor
+
+
+class DefaultQualityEvaluator(QualityEvaluator):
+    """Wrap QualityAssessor into QualityEvaluator interface."""
+
+    def __init__(self, similarity_fn: Callable[[str, str], float]) -> None:
+        self.assessor = QualityAssessor(similarity_fn)
+
+    def score(self, response: str, prompt: str) -> float:
+        return self.assessor.comprehensive_score(response, prompt)["overall"]

--- a/core/resilience.py
+++ b/core/resilience.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import asyncio
+import random
+from dataclasses import dataclass
+
+
+class APIError(Exception):
+    """Base exception for API related errors."""
+
+
+class RateLimitError(APIError):
+    """Raised when the API rate limit is exceeded."""
+
+
+class TokenLimitError(APIError):
+    """Raised when the request exceeds the allowed token limit."""
+
+
+@dataclass
+class RetryState:
+    max_retries: int = 3
+    failure_count: int = 0
+
+
+async def with_retry(coro, state: RetryState) -> str:
+    for attempt in range(1, state.max_retries + 1):
+        try:
+            return await coro()
+        except (APIError, RateLimitError, TokenLimitError) as e:
+            state.failure_count += 1
+            if attempt == state.max_retries:
+                raise e
+            await asyncio.sleep(2 ** (attempt - 1) + random.random())
+    raise APIError("unreachable")

--- a/tests/test_chat_engine.py
+++ b/tests/test_chat_engine.py
@@ -1,0 +1,26 @@
+import asyncio
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from core.chat_engine import ChatEngine
+from core.cache_provider import InMemoryCache
+from core.interfaces import LLMProvider
+from core.quality_evaluator import DefaultQualityEvaluator
+
+
+class DummyLLM(LLMProvider):
+    async def chat(self, messages, *, temperature=0.7):
+        prompt = messages[-1]["content"]
+        return prompt.upper()
+
+
+def test_engine_runs_event_loop():
+    engine = ChatEngine(
+        llm=DummyLLM(),
+        cache=InMemoryCache(),
+        evaluator=DefaultQualityEvaluator(lambda a, b: 1.0 if a == b.upper() else 0.0),
+    )
+    result = asyncio.run(engine.think("hello", max_rounds=1))
+    assert result == "HELLO"


### PR DESCRIPTION
## Summary
- add new provider interfaces and default implementations
- add ChatEngine with adaptive reasoning loop
- implement small resilience helper with retry
- create context manager variant
- cover ChatEngine with a basic test

## Testing
- `flake8 core/chat_engine.py core/cache_provider.py core/interfaces.py core/resilience.py tests/test_chat_engine.py core/quality_evaluator.py core/llm_provider.py core/context_manager.py`
- `pytest -q tests/test_chat_engine.py`

------
https://chatgpt.com/codex/tasks/task_e_6845bb6a354483339afcbafff65d71c4