### PR TITLE
Add adaptive reasoning and resilience

### DIFF
--- a/core/adaptive_reasoning.py
+++ b/core/adaptive_reasoning.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import List
+
+from core.interfaces import LLMProvider, QualityEvaluator
+
+
+@dataclass
+class ReasoningState:
+    current_best: str
+    confidence: float
+    history: List[float] = field(default_factory=list)
+    stability_count: int = 0
+
+
+class AdaptiveReasoner:
+    """Iteratively improve a response with adaptive stopping."""
+
+    def __init__(self, llm: LLMProvider, evaluator: QualityEvaluator) -> None:
+        self.llm = llm
+        self.evaluator = evaluator
+
+    async def reason(self, prompt: str, *, max_rounds: int = 5) -> str:
+        initial = await self.llm.chat([{"role": "user", "content": prompt}])
+        score = self.evaluator.score(initial, prompt)
+        state = ReasoningState(initial, score, [score])
+
+        for _ in range(1, max_rounds + 1):
+            if state.confidence > 0.95 and state.stability_count >= 2:
+                break
+
+            num_alts = self._num_alternatives(state.confidence)
+            tasks = [
+                asyncio.create_task(
+                    self.llm.chat(
+                        [{"role": "user", "content": f"{prompt}\nImprovement {i}"}]
+                    )
+                )
+                for i in range(num_alts)
+            ]
+            done, _ = await asyncio.wait(tasks, timeout=30)
+            best = state.current_best
+            best_score = state.confidence
+            for task in done:
+                text = task.result()
+                score = self.evaluator.score(text, prompt)
+                if score > best_score:
+                    best = text
+                    best_score = score
+            if best == state.current_best:
+                state.stability_count += 1
+            else:
+                state.stability_count = 0
+            state.current_best = best
+            state.confidence = best_score
+            state.history.append(best_score)
+
+            if len(state.history) > 3:
+                last3 = state.history[-3:]
+                if max(last3) - min(last3) < 0.01:
+                    break
+
+        return state.current_best
+
+    @staticmethod
+    def _num_alternatives(conf: float) -> int:
+        if conf > 0.9:
+            return 2
+        if conf > 0.7:
+            return 3
+        return 4

--- a/core/resilient_provider.py
+++ b/core/resilient_provider.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import asyncio
+from typing import List, Dict
+
+from core.interfaces import LLMProvider
+from exceptions import APIError, RateLimitError, TokenLimitError
+from core.resilience import RetryState, with_retry
+
+
+class ResilientLLMProvider(LLMProvider):
+    """Wrap LLM providers with retry and fallback logic."""
+
+    def __init__(self, primary: LLMProvider, fallbacks: List[LLMProvider] | None = None) -> None:
+        self.primary = primary
+        self.fallbacks = fallbacks or []
+
+    async def chat(self, messages: List[Dict[str, str]], *, temperature: float = 0.7) -> str:
+        providers = [self.primary] + self.fallbacks
+        for idx, provider in enumerate(providers):
+            try:
+                return await with_retry(
+                    lambda: provider.chat(messages, temperature=temperature),
+                    RetryState(),
+                )
+            except RateLimitError as e:
+                if idx == len(providers) - 1:
+                    raise e
+                await asyncio.sleep(2 ** idx)
+            except TokenLimitError as e:
+                if idx == len(providers) - 1:
+                    raise e
+            except APIError:
+                if idx == len(providers) - 1:
+                    raise
+        raise APIError("all providers failed")

--- a/docs/ARCHITECTURE_AUDIT.md
+++ b/docs/ARCHITECTURE_AUDIT.md
@@ -1,0 +1,34 @@
+# Chain of Recursive Thought (CoRT) Architecture Audit
+
+## Executive Summary
+
+The repository implements an interesting recursive reasoning architecture, but suffers from architectural issues like tight coupling, circular dependencies, poor error handling, and inefficient resource usage. The concept is sound, but the implementation needs refactoring for production readiness.
+
+## Critical Issues & Solutions
+
+### 1. Architectural Problems
+- A monolithic chat class mixes API calls, caching, circuit breaking, context management, and logging.
+- Split responsibilities using dependency injection and interfaces.
+
+### 2. Recursive Algorithm Inefficiencies
+- Currently regenerates alternatives each round without adaptive stopping.
+- Implement an adaptive reasoner with early stopping and parallel generation.
+
+### 3. Poor Error Handling & Resilience
+- Add a resilient provider wrapper to handle failures and circuit breaking.
+
+### 4. Inefficient Context Management
+- Replace naive truncation with semantic context compression.
+
+### 5. Missing Monitoring & Observability
+- Collect detailed metrics on thinking efficiency, convergence, and resource usage.
+
+### 6. Testing Strategy
+- Add pytest-based unit and integration tests.
+
+## Priority Implementation Roadmap
+
+1. **Critical Fixes**: refactor core class, add resilience, monitoring, and tests.
+2. **Performance Optimization**: adaptive reasoning and improved context management.
+3. **Production Readiness**: documentation, configuration management, and deployment optimization.
+

--- a/monitoring/advanced_metrics.py
+++ b/monitoring/advanced_metrics.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from collections import defaultdict, deque
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+
+@dataclass
+class DetailedMetrics:
+    session_id: str
+    quality_progression: List[float] = field(default_factory=list)
+    resource_usage: Dict[str, float] = field(default_factory=dict)
+    error_count: int = 0
+
+
+class AdvancedMetricsCollector:
+    """Collect detailed metrics for analysis."""
+
+    def __init__(self) -> None:
+        self.sessions: Dict[str, DetailedMetrics] = {}
+        self.global_stats = defaultdict(deque)
+
+    def start_session(self, session_id: str) -> None:
+        self.sessions[session_id] = DetailedMetrics(session_id)
+
+    def record_round(
+        self,
+        session_id: str,
+        round_num: int,
+        quality_score: float,
+        tokens_used: int,
+        time_elapsed: float,
+    ) -> None:
+        metrics = self.sessions.get(session_id)
+        if not metrics:
+            metrics = DetailedMetrics(session_id)
+            self.sessions[session_id] = metrics
+        metrics.quality_progression.append(quality_score)
+        metrics.resource_usage[f"round_{round_num}"] = {
+            "tokens": tokens_used,
+            "time": time_elapsed,
+        }
+
+    def increment_error(self, session_id: str) -> None:
+        metrics = self.sessions.get(session_id)
+        if metrics:
+            metrics.error_count += 1
+
+    def get_progress(self, session_id: str) -> List[float]:
+        metrics = self.sessions.get(session_id)
+        return metrics.quality_progression if metrics else []

--- a/tests/test_adaptive_reasoning.py
+++ b/tests/test_adaptive_reasoning.py
@@ -1,0 +1,41 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
+
+import asyncio  # noqa: E402
+from typing import List, Dict  # noqa: E402
+
+from core.adaptive_reasoning import AdaptiveReasoner  # noqa: E402
+from core.interfaces import LLMProvider, QualityEvaluator  # noqa: E402
+
+
+class DummyLLM(LLMProvider):
+    def __init__(self, responses: List[str]):
+        self.responses = responses
+        self.idx = 0
+
+    async def chat(self, messages: List[Dict[str, str]], *, temperature: float = 0.7) -> str:
+        resp = self.responses[min(self.idx, len(self.responses) - 1)]
+        self.idx += 1
+        return resp
+
+
+class DummyEval(QualityEvaluator):
+    def __init__(self, scores):
+        self.scores = scores
+
+    def score(self, response: str, prompt: str) -> float:
+        return self.scores.get(response, 0.0)
+
+
+async def run_reasoner():
+    llm = DummyLLM(["bad", "better", "best", "best"])
+    evaluator = DummyEval({"bad": 0.1, "better": 0.6, "best": 0.96})
+    reasoner = AdaptiveReasoner(llm, evaluator)
+    return await reasoner.reason("hi", max_rounds=5)
+
+
+def test_adaptive_reasoning_converges():
+    result = asyncio.run(run_reasoner())
+    assert result == "best"

--- a/tests/test_advanced_metrics.py
+++ b/tests/test_advanced_metrics.py
@@ -1,0 +1,15 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
+
+from monitoring.advanced_metrics import AdvancedMetricsCollector  # noqa: E402
+
+
+def test_record_and_retrieve():
+    collector = AdvancedMetricsCollector()
+    collector.start_session("s1")
+    collector.record_round("s1", 1, 0.5, 10, 0.1)
+    collector.record_round("s1", 2, 0.6, 12, 0.2)
+    progress = collector.get_progress("s1")
+    assert progress == [0.5, 0.6]

--- a/tests/test_resilient_provider.py
+++ b/tests/test_resilient_provider.py
@@ -1,0 +1,42 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
+
+import asyncio  # noqa: E402
+from typing import List, Dict  # noqa: E402
+
+from core.resilient_provider import ResilientLLMProvider  # noqa: E402
+from core.interfaces import LLMProvider  # noqa: E402
+from exceptions import APIError, RateLimitError  # noqa: E402
+
+
+class FailingLLM(LLMProvider):
+    def __init__(self, exc):
+        self.exc = exc
+
+    async def chat(self, messages: List[Dict[str, str]], *, temperature: float = 0.7) -> str:
+        raise self.exc
+
+
+class SuccessLLM(LLMProvider):
+    async def chat(self, messages: List[Dict[str, str]], *, temperature: float = 0.7) -> str:
+        return "ok"
+
+
+def test_resilient_provider_uses_fallback():
+    provider = ResilientLLMProvider(
+        FailingLLM(APIError("boom")), [SuccessLLM()]
+    )
+    result = asyncio.run(provider.chat([{"role": "user", "content": "hi"}]))
+    assert result == "ok"
+
+
+def test_resilient_provider_reraises():
+    provider = ResilientLLMProvider(FailingLLM(RateLimitError("limit")))
+    try:
+        asyncio.run(provider.chat([{"role": "user", "content": "hi"}]))
+    except RateLimitError:
+        assert True
+    else:
+        assert False


### PR DESCRIPTION
## Summary
- implement AdaptiveReasoner for improved recursive thinking
- add ResilientLLMProvider with retry and fallback logic
- provide advanced metrics collector for detailed monitoring
- include unit tests for new modules

## Testing
- `flake8 core/adaptive_reasoning.py core/resilient_provider.py monitoring/advanced_metrics.py tests/test_adaptive_reasoning.py tests/test_resilient_provider.py tests/test_advanced_metrics.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845bd81b3ec83338e50843a1dd74eed