### PR TITLE
Add simple public API docs

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,14 @@
+
+"""OpenRouter API helpers."""
+
+from .openrouter import (
+    sync_chat_completion,
+    async_chat_completion,
+    get_embeddings,
+)
+
+__all__ = [
+    "sync_chat_completion",
+    "async_chat_completion",
+    "get_embeddings",
+]

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,0 +1,6 @@
+
+"""Console entry helpers for RecThink."""
+
+from .main import main
+
+__all__ = ["main"]

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,18 @@
+
+"""High-level chat framework."""
+
+from .chat import (
+    CoRTConfig,
+    EnhancedRecursiveThinkingChat,
+    AsyncEnhancedRecursiveThinkingChat,
+)
+from .recursion import ConvergenceTracker
+from .adaptive_reasoning import AdaptiveReasoner
+
+__all__ = [
+    "CoRTConfig",
+    "EnhancedRecursiveThinkingChat",
+    "AsyncEnhancedRecursiveThinkingChat",
+    "ConvergenceTracker",
+    "AdaptiveReasoner",
+]

--- a/core/providers/__init__.py
+++ b/core/providers/__init__.py
@@ -1,0 +1,45 @@
+
+"""Provider interfaces and implementations."""
+
+from .cache import (
+    CacheProvider,
+    CacheEntry,
+    InMemoryLRUCache,
+    DiskCacheProvider,
+    HybridCacheProvider,
+    RedisCacheProvider,
+)
+from .embeddings import (
+    OpenRouterEmbeddingProvider,
+    CachedEmbeddingProvider,
+    LocalEmbeddingProvider,
+)
+from .llm import (
+    LLMResponse,
+    StandardLLMResponse,
+    LLMProvider,
+    OpenRouterLLMProvider,
+    MultiProviderLLM,
+)
+from .quality import EnhancedQualityEvaluator, SimpleQualityEvaluator
+from .resilient_llm import ResilientLLMProvider
+
+__all__ = [
+    "CacheProvider",
+    "CacheEntry",
+    "InMemoryLRUCache",
+    "DiskCacheProvider",
+    "HybridCacheProvider",
+    "RedisCacheProvider",
+    "OpenRouterEmbeddingProvider",
+    "CachedEmbeddingProvider",
+    "LocalEmbeddingProvider",
+    "LLMResponse",
+    "StandardLLMResponse",
+    "LLMProvider",
+    "OpenRouterLLMProvider",
+    "MultiProviderLLM",
+    "EnhancedQualityEvaluator",
+    "SimpleQualityEvaluator",
+    "ResilientLLMProvider",
+]

--- a/core/resilience/__init__.py
+++ b/core/resilience/__init__.py
@@ -1,0 +1,20 @@
+
+"""Retry policy utilities."""
+
+from .retry_policies import (
+    ExponentialBackoffPolicy,
+    LinearBackoffPolicy,
+    AdaptiveRetryPolicy,
+    RetryExecutor,
+    HedgingExecutor,
+    CombinedExecutor,
+)
+
+__all__ = [
+    "ExponentialBackoffPolicy",
+    "LinearBackoffPolicy",
+    "AdaptiveRetryPolicy",
+    "RetryExecutor",
+    "HedgingExecutor",
+    "CombinedExecutor",
+]


### PR DESCRIPTION
## Summary
- document `cli`, `api`, `core`, `core.providers`, and `core.resilience` packages
- define minimal `__all__` lists for those modules

## Testing
- `flake8 cli/__init__.py api/__init__.py core/providers/__init__.py core/__init__.py core/resilience/__init__.py`
- `pytest -q` *(fails: 5 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68477d2e3aa8833385c0b5483b9212d4