### PR TITLE
Expose retry helpers

### DIFF
--- a/core/resilience/__init__.py
+++ b/core/resilience/__init__.py
@@ -9,7 +9,7 @@ from .retry_policies import (
     HedgingExecutor,
     CombinedExecutor,
 )
-from ..resilience import RetryState, with_retry
+from .resilience import RetryState, with_retry
 
 __all__ = [
     "ExponentialBackoffPolicy",

--- a/core/resilience/resilience.py
+++ b/core/resilience/resilience.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import asyncio
+import random
+from dataclasses import dataclass
+
+
+class APIError(Exception):
+    """Base exception for API related errors."""
+
+
+class RateLimitError(APIError):
+    """Raised when the API rate limit is exceeded."""
+
+
+class TokenLimitError(APIError):
+    """Raised when the request exceeds the allowed token limit."""
+
+
+@dataclass
+class RetryState:
+    max_retries: int = 3
+    failure_count: int = 0
+
+
+async def with_retry(coro, state: RetryState) -> str:
+    for attempt in range(1, state.max_retries + 1):
+        try:
+            return await coro()
+        except (APIError, RateLimitError, TokenLimitError) as e:
+            state.failure_count += 1
+            if attempt == state.max_retries:
+                raise e
+            await asyncio.sleep(2 ** (attempt - 1) + random.random())
+    raise APIError("unreachable")
+
+
+__all__ = ["RetryState", "with_retry"]


### PR DESCRIPTION
## Summary
- export RetryState and with_retry via `core.resilience`
- mirror retry utilities inside `core/resilience/resilience.py`

## Testing
- `flake8 core/resilience/__init__.py core/resilience/resilience.py`
- `pytest -k "nothing" -q` *(fails: ModuleNotFoundError: No module named 'aiofiles')*

------
https://chatgpt.com/codex/tasks/task_e_6847b9d1e27083338c98ecc22604309c