### PR TITLE
Update README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@
 ## How to use the Web UI(still early dev)
 1. Open start_recthink.bat
 2. wait for a bit as it installs dependencies
-3. profit??
+3. If new packages are added, rerun `pip install -r requirements.txt`
+4. profit??
 
 If running on Linux:
 ```
@@ -62,7 +63,15 @@ Install the requirements and execute pytest:
 ```bash
 pip install -r requirements.txt
 pip install pytest flake8
+flake8
 pytest
+```
+
+If you add new packages to `requirements.txt`, run the full installation step
+again:
+
+```bash
+pip install -r requirements.txt
 ```
 
 To run only the integration scenarios:


### PR DESCRIPTION
## Summary
- document rerunning `pip install -r requirements.txt` when adding new packages
- mention `flake8` and `pytest` after installing requirements

## Testing
- `flake8`
- `pytest` *(fails: ModuleNotFoundError for numpy, opentelemetry.instrumentation, cryptography)*

------
https://chatgpt.com/codex/tasks/task_e_68488374daa48333ad7111db96b63c40