### PR TITLE
Update cache provider typing imports

### DIFF
--- a/core/providers/cache.py
+++ b/core/providers/cache.py
@@ -10,7 +10,7 @@ import time
 from collections import OrderedDict
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, Optional, Protocol, Union
+from typing import Any, Dict, List, Optional, Protocol, Union
 
 import aiofiles
 import structlog


### PR DESCRIPTION
## Summary
- include `List` in cache provider typing imports
- ensure file ends with newline

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: core.resilience.circuit_breaker)*

------
https://chatgpt.com/codex/tasks/task_e_684892c421208333bd2f871db27b99eb