### PR TITLE
fix: remove unused Optional import

### DIFF
--- a/core/providers/embeddings.py
+++ b/core/providers/embeddings.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import hashlib
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 import numpy as np
 from api import openrouter


### PR DESCRIPTION
## Summary
- cleanup unused Optional import in embeddings provider

## Testing
- `flake8 core/providers/embeddings.py`
- `pytest -q` *(fails: PytestUnknownMarkWarning and 3 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68489d9a66ac833399653d93d94e0570