### PR TITLE
Refactor chat to use client and cache

### DIFF
--- a/core/cache_manager.py
+++ b/core/cache_manager.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import os
+import pickle
+from collections import OrderedDict
+from typing import Any, Tuple
+
+
+class CacheManager:
+    """Simple in-memory and optional disk cache manager."""
+
+    def __init__(
+        self,
+        enabled: bool = True,
+        memory_size: int = 128,
+        disk_path: str | None = None,
+        disk_size: int = 256,
+    ) -> None:
+        self.enabled = enabled
+        self.memory_size = memory_size
+        self.disk_path = disk_path
+        self.disk_size = disk_size
+        self.memory: OrderedDict[Tuple[str, str], Any] = OrderedDict()
+        self.disk: OrderedDict[Tuple[str, str], Any] = OrderedDict()
+        if self.disk_path:
+            self._load_disk()
+
+    # basic LRU management
+    def get(self, key: Tuple[str, str]) -> Any | None:
+        if not self.enabled:
+            return None
+        if key in self.memory:
+            self.memory.move_to_end(key)
+            return self.memory[key]
+        if key in self.disk:
+            value = self.disk[key]
+            self.memory[key] = value
+            self.memory.move_to_end(key)
+            if len(self.memory) > self.memory_size:
+                self.memory.popitem(last=False)
+            return value
+        return None
+
+    def set(self, key: Tuple[str, str], value: Any) -> None:
+        if not self.enabled:
+            return
+        self.memory[key] = value
+        self.memory.move_to_end(key)
+        if len(self.memory) > self.memory_size:
+            self.memory.popitem(last=False)
+        if self.disk_path:
+            self.disk[key] = value
+            if len(self.disk) > self.disk_size:
+                self.disk.popitem(last=False)
+            self._save_disk()
+
+    def _load_disk(self) -> None:
+        if not self.disk_path or not os.path.exists(self.disk_path):
+            return
+        try:
+            with open(self.disk_path, "rb") as f:
+                data = pickle.load(f)
+            if isinstance(data, dict):
+                self.disk = OrderedDict(data)
+                while len(self.disk) > self.disk_size:
+                    self.disk.popitem(last=False)
+        except Exception:
+            self.disk = OrderedDict()
+
+    def _save_disk(self) -> None:
+        if not self.disk_path:
+            return
+        try:
+            with open(self.disk_path, "wb") as f:
+                pickle.dump(self.disk, f)
+        except Exception:
+            pass
+

--- a/core/llm_client.py
+++ b/core/llm_client.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import asyncio
+import random
+import time
+from typing import List, Dict, Optional
+
+import aiohttp
+
+from api import openrouter
+from exceptions import APIError, RateLimitError, TokenLimitError
+from config import settings
+
+
+class LLMClient:
+    """Handle all communication with the OpenRouter API."""
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        model: Optional[str] = None,
+        max_retries: int = 3,
+    ) -> None:
+        self.api_key = api_key or settings.openrouter_api_key
+        self.model = model or settings.model
+        self.headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "HTTP-Referer": settings.frontend_url,
+            "X-Title": "Recursive Thinking Chat",
+            "Content-Type": "application/json",
+        }
+        self.max_retries = max_retries
+        self.failure_count = 0
+        self.circuit_open = False
+        self.circuit_reset_time = 0.0
+        self.session: aiohttp.ClientSession | None = None
+
+    async def close(self) -> None:
+        if self.session is not None:
+            await self.session.close()
+
+    # Synchronous call helper used by EnhancedRecursiveThinkingChat
+    def chat(
+        self,
+        messages: List[Dict],
+        *,
+        temperature: float = 0.7,
+        stream: bool = True,
+    ) -> str:
+        if self.circuit_open:
+            if time.time() < self.circuit_reset_time:
+                raise APIError("Circuit breaker open")
+            self.circuit_open = False
+            self.failure_count = 0
+        for attempt in range(1, self.max_retries + 1):
+            try:
+                return openrouter.sync_chat_completion(
+                    self.headers,
+                    messages,
+                    self.model,
+                    temperature=temperature,
+                    stream=stream,
+                )
+            except (APIError, RateLimitError, TokenLimitError, Exception) as e:
+                self.failure_count += 1
+                if attempt == self.max_retries:
+                    self.circuit_open = True
+                    self.circuit_reset_time = time.time() + 2 ** attempt
+                    raise e
+                delay = 2 ** (attempt - 1) + random.uniform(0, 1)
+                time.sleep(delay)
+        raise APIError("Failed to get response")
+
+    async def async_chat(
+        self,
+        messages: List[Dict],
+        *,
+        temperature: float = 0.7,
+    ) -> str:
+        if self.circuit_open:
+            if time.time() < self.circuit_reset_time:
+                raise APIError("Circuit breaker open")
+            self.circuit_open = False
+            self.failure_count = 0
+        for attempt in range(1, self.max_retries + 1):
+            try:
+                if self.session is None:
+                    self.session = aiohttp.ClientSession()
+                return await openrouter.async_chat_completion(
+                    self.headers,
+                    messages,
+                    self.model,
+                    temperature=temperature,
+                    session=self.session,
+                )
+            except (APIError, RateLimitError, TokenLimitError, Exception) as e:
+                self.failure_count += 1
+                if attempt == self.max_retries:
+                    self.circuit_open = True
+                    self.circuit_reset_time = time.time() + 2 ** attempt
+                    raise e
+                delay = 2 ** (attempt - 1) + random.uniform(0, 1)
+                await asyncio.sleep(delay)
+        raise APIError("Failed to get response")
+
+    def embeddings(self, texts: List[str]):
+        return openrouter.get_embeddings(self.headers, texts)
+

--- a/tests/test_cache_manager.py
+++ b/tests/test_cache_manager.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import importlib.util
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, ROOT)
+spec = importlib.util.spec_from_file_location(
+    "cache_manager", os.path.join(ROOT, "core", "cache_manager.py")
+)
+cache_manager = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cache_manager)
+CacheManager = cache_manager.CacheManager
+
+
+def test_memory_lru():
+    cm = CacheManager(enabled=True, memory_size=2)
+    cm.set(("a", "1"), "x")
+    cm.set(("b", "1"), "y")
+    cm.set(("c", "1"), "z")
+    assert cm.get(("a", "1")) is None
+    assert cm.get(("b", "1")) == "y"
+
+
+def test_disk_persistence(tmp_path):
+    path = tmp_path / "cache.pkl"
+    cm1 = CacheManager(enabled=True, memory_size=1, disk_path=str(path), disk_size=2)
+    cm1.set(("k", "1"), "v")
+
+    cm2 = CacheManager(enabled=True, memory_size=1, disk_path=str(path), disk_size=2)
+    assert cm2.get(("k", "1")) == "v"
+

--- a/tests/test_convergence_scoring.py
+++ b/tests/test_convergence_scoring.py
@@ -1,0 +1,29 @@
+import os
+import sys
+import importlib.util
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, ROOT)
+spec = importlib.util.spec_from_file_location(
+    "recursion", os.path.join(ROOT, "core", "recursion.py")
+)
+recursion = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(recursion)
+ConvergenceTracker = recursion.ConvergenceTracker
+QualityAssessor = recursion.QualityAssessor
+
+
+def test_convergence_detection():
+    tracker = ConvergenceTracker(lambda a, b: 1.0 if a == b else 0.0, lambda r, p: len(r))
+    tracker.add("one", "p")
+    tracker.add("one", "p")
+    cont, reason = tracker.should_continue("p")
+    assert not cont
+    assert reason == "converged"
+
+
+def test_quality_assessor():
+    qa = QualityAssessor(lambda a, b: 1.0 if a == b else 0.0)
+    score = qa.comprehensive_score("hello", "hello")
+    assert score["overall"] >= 1.0
+

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,0 +1,41 @@
+import asyncio
+import pytest
+import os
+import sys
+import importlib.util
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, ROOT)
+spec = importlib.util.spec_from_file_location(
+    "llm_client", os.path.join(ROOT, "core", "llm_client.py")
+)
+llm_client = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(llm_client)
+LLMClient = llm_client.LLMClient
+
+
+def test_sync_chat(monkeypatch):
+    called = {}
+
+    def fake_sync(headers, messages, model, temperature=0.7, stream=True):
+        called['args'] = (headers, messages, model, temperature, stream)
+        return "ok"
+
+    monkeypatch.setattr("api.openrouter.sync_chat_completion", fake_sync)
+    client = LLMClient(api_key="k", model="m", max_retries=1)
+    resp = client.chat([{"role": "user", "content": "hi"}], stream=False)
+    assert resp == "ok"
+    assert called['args'][2] == "m"
+
+
+@pytest.mark.asyncio
+async def test_async_chat(monkeypatch):
+    async def fake_async(headers, messages, model, temperature=0.7, session=None):
+        return "async"
+
+    monkeypatch.setattr("api.openrouter.async_chat_completion", fake_async)
+    client = LLMClient(api_key="k", model="m", max_retries=1)
+    resp = await client.async_chat([{"role": "user", "content": "hi"}])
+    await client.close()
+    assert resp == "async"
+


### PR DESCRIPTION
## Summary
- add `LLMClient` for API communication and retries
- implement `CacheManager` with optional disk persistence
- refactor `EnhancedRecursiveThinkingChat` to depend on these classes
- add unit tests for the new components

## Testing
- `flake8 core/llm_client.py core/cache_manager.py core/chat.py tests/test_cache_manager.py tests/test_llm_client.py tests/test_convergence_scoring.py`
- `pytest tests/test_llm_client.py tests/test_cache_manager.py tests/test_convergence_scoring.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6848da4c88d4833398959b5a6551e9e9