### PR TITLE
Add async context manager support

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from core.chat_v2 import CoRTConfig, create_default_engine
+from core.chat import AsyncEnhancedRecursiveThinkingChat, CoRTConfig
 from config import settings
 
 
@@ -20,36 +20,40 @@ async def main() -> None:
         return
 
     config = CoRTConfig(api_key=api_key, model=settings.model)
-    chat = create_default_engine(config)
 
-    print("\nChat initialized! Type 'exit' to quit, 'save' to save conversation.")
-    print("The AI will think recursively before each response.\n")
+    async with AsyncEnhancedRecursiveThinkingChat(config) as chat:
+        print(
+            "\nChat initialized! Type 'exit' to quit, 'save' to save conversation."
+        )
+        print("The AI will think recursively before each response.\n")
 
-    while True:
-        user_input = input("You: ").strip()
-        if user_input.lower() == "exit":
-            break
-        if user_input.lower() == "save":
+        while True:
+            user_input = input("You: ").strip()
+            if user_input.lower() == "exit":
+                break
+            if user_input.lower() == "save":
+                await chat.save_conversation("conversation.json")
+                continue
+            if not user_input:
+                continue
+
+            result = await chat.think_and_respond(user_input)
+            print(f"\n🤖 AI FINAL RESPONSE: {result.response}\n")
+            print("\n--- COMPLETE THINKING PROCESS ---")
+            for item in result.thinking_history:
+                label = "[SELECTED]" if item.get("selected") else "[ALTERNATIVE]"
+                print(f"\nRound {item['round']} {label}:")
+                print(f"  Response: {item['response']}")
+                if item.get("explanation") and item.get("selected"):
+                    print(f"  Reason for selection: {item['explanation']}")
+                print("-" * 50)
+            print("--------------------------------\n")
+
+        save_on_exit = (
+            input("Save conversation before exiting? (y/n): ").strip().lower()
+        )
+        if save_on_exit == "y":
             await chat.save_conversation("conversation.json")
-            continue
-        if not user_input:
-            continue
-
-        result = await chat.think_and_respond(user_input)
-        print(f"\n🤖 AI FINAL RESPONSE: {result.response}\n")
-        print("\n--- COMPLETE THINKING PROCESS ---")
-        for item in result.thinking_history:
-            label = "[SELECTED]" if item.get("selected") else "[ALTERNATIVE]"
-            print(f"\nRound {item['round']} {label}:")
-            print(f"  Response: {item['response']}")
-            if item.get("explanation") and item.get("selected"):
-                print(f"  Reason for selection: {item['explanation']}")
-            print("-" * 50)
-        print("--------------------------------\n")
-
-    save_on_exit = input("Save conversation before exiting? (y/n): ").strip().lower()
-    if save_on_exit == "y":
-        await chat.save_conversation("conversation.json")
     print("Goodbye! 👋")
 
 

--- a/core/chat.py
+++ b/core/chat.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import random
+import aiohttp
 import re
 import time
 from dataclasses import dataclass, field
@@ -413,6 +414,14 @@ class AsyncEnhancedRecursiveThinkingChat(EnhancedRecursiveThinkingChat):
     def __init__(self, config: CoRTConfig, max_connections: int = 5) -> None:
         super().__init__(config)
         self.semaphore = asyncio.Semaphore(max_connections)
+
+    async def __aenter__(self) -> "AsyncEnhancedRecursiveThinkingChat":
+        if self.llm_client.session is None:
+            self.llm_client.session = aiohttp.ClientSession()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        await self.close()
 
     async def close(self) -> None:
         await self.llm_client.close()

--- a/tests/test_async_chat_context.py
+++ b/tests/test_async_chat_context.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import pytest
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, ROOT)
+import types  # noqa: E402
+cb_mod = types.ModuleType('cb')
+cb_mod.CircuitBreaker = type('CircuitBreaker', (), {})
+cb_mod.CircuitOpenError = type('CircuitOpenError', (Exception,), {})
+sys.modules.setdefault('core.resilience.circuit_breaker', cb_mod)
+
+import core.chat as chat  # noqa: E402
+
+AsyncEnhancedRecursiveThinkingChat = chat.AsyncEnhancedRecursiveThinkingChat
+CoRTConfig = chat.CoRTConfig
+
+
+class DummySession:
+    def __init__(self):
+        self.closed = False
+
+    async def close(self):
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_context_closes_session(monkeypatch):
+    monkeypatch.setattr('aiohttp.ClientSession', lambda: DummySession())
+
+    chat = AsyncEnhancedRecursiveThinkingChat(CoRTConfig(api_key='k', model='m'))
+    async with chat:
+        assert chat.llm_client.session is not None
+    assert chat.llm_client.session.closed


### PR DESCRIPTION
## Summary
- add `__aenter__` and `__aexit__` to `AsyncEnhancedRecursiveThinkingChat`
- use `async with` in CLI and API server
- fallback `close()` still supported
- test session closes after leaving context

## Testing
- `flake8 cli/main.py recthink_web.py core/chat.py tests/test_async_chat_context.py`
- `pytest tests/test_async_chat_context.py -q`
- `pytest -q` *(fails: ModuleNotFoundError in other tests)*

------
https://chatgpt.com/codex/tasks/task_e_6848dc767864833380ec46674020b81a