### PR TITLE
Add streaming API and websocket support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ cd frontend
 npm start
 ```
 
+### WebSocket streaming
+The backend exposes a WebSocket endpoint for progressive updates.
+Connect to `/ws/{session_id}` after initializing a session.
+Each update has `type: "chunk"` with a partial response.
+When processing completes the server sends `type: "final"` with the
+full thinking history.
+
 ## Try it yourself
 ### CLI usage
 ```bash


### PR DESCRIPTION
## Summary
- expose `stream_think_and_respond` on `AsyncEnhancedRecursiveThinkingChat`
- update WebSocket endpoint to stream progressive updates
- document WebSocket streaming usage

## Testing
- `flake8 core/chat.py recthink_web.py`
- `pytest -q` *(fails: Unknown pytest marks and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6848eb687c448333b16a88d649aaaecc