### PR TITLE
Add rolling trend convergence tracking

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -7,7 +7,7 @@ from .chat_v2 import (
     AdaptiveThinkingStrategy,
     create_default_engine,
 )
-from .recursion import ConvergenceTracker
+from .recursion import ConvergenceTracker, TrendConvergenceStrategy
 from .adaptive_reasoning import AdaptiveReasoner
 
 __all__ = [
@@ -16,5 +16,6 @@ __all__ = [
     "AdaptiveThinkingStrategy",
     "create_default_engine",
     "ConvergenceTracker",
+    "TrendConvergenceStrategy",
     "AdaptiveReasoner",
 ]

--- a/tests/test_convergence_scoring.py
+++ b/tests/test_convergence_scoring.py
@@ -10,6 +10,7 @@ spec = importlib.util.spec_from_file_location(
 recursion = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(recursion)
 ConvergenceTracker = recursion.ConvergenceTracker
+TrendConvergenceStrategy = recursion.TrendConvergenceStrategy
 QualityAssessor = recursion.QualityAssessor
 
 
@@ -27,3 +28,19 @@ def test_quality_assessor():
     score = qa.comprehensive_score("hello", "hello")
     assert score["overall"] >= 1.0
 
+
+def test_rolling_average_and_plateau_detection():
+    strategy = TrendConvergenceStrategy(improvement_threshold=0.05, window=2)
+    tracker = ConvergenceTracker(
+        lambda a, b: 0.0,
+        lambda r, p: float(r),
+        strategy=strategy,
+    )
+
+    for resp in ["0.1", "0.11", "0.115", "0.116"]:
+        tracker.add(resp, "p")
+
+    assert abs(tracker.rolling_average - 0.11025) < 1e-6
+    cont, reason = tracker.should_continue("p")
+    assert not cont
+    assert reason == "quality plateau"


### PR DESCRIPTION
## Summary
- extend `ConvergenceTracker` with new `TrendConvergenceStrategy`
- compute moving-average plateau detection
- expose new strategy in package `__all__`
- test rolling stats and plateau logic

## Testing
- `flake8 core/recursion.py tests/test_convergence_scoring.py core/__init__.py`
- `pytest tests/test_convergence_scoring.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: core.resilience.circuit_breaker)*

------
https://chatgpt.com/codex/tasks/task_e_6848ed47757083339f0bea5b013fa3fb