### PR TITLE
Add recthink_web_v2 and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If running on Linux:
 pip install -r requirements.txt
 cd frontend && npm install
 cd ..
-python recthink_web.py  # start the API server
+python recthink_web_v2.py  # start the API server
 ```
 
 (open a new shell)

--- a/cli/main.py
+++ b/cli/main.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from core.chat import AsyncEnhancedRecursiveThinkingChat, CoRTConfig
+from core.chat_v2 import CoRTConfig, create_default_engine
 from config import settings
 
 
@@ -11,7 +11,7 @@ async def main() -> None:
         exit      Quit the program.
         save      Save the conversation history to ``conversation.json``.
     """
-    print("🤖 Enhanced Recursive Thinking Chat")
+    print("🤖 Recursive Thinking Chat v2")
     print("=" * 50)
 
     api_key = settings.openrouter_api_key
@@ -20,40 +20,36 @@ async def main() -> None:
         return
 
     config = CoRTConfig(api_key=api_key, model=settings.model)
+    engine = create_default_engine(config)
 
-    async with AsyncEnhancedRecursiveThinkingChat(config) as chat:
-        print(
-            "\nChat initialized! Type 'exit' to quit, 'save' to save conversation."
-        )
-        print("The AI will think recursively before each response.\n")
+    print("\nChat initialized! Type 'exit' to quit, 'save' to save conversation.")
+    print("The AI will think recursively before each response.\n")
 
-        while True:
-            user_input = input("You: ").strip()
-            if user_input.lower() == "exit":
-                break
-            if user_input.lower() == "save":
-                await chat.save_conversation("conversation.json")
-                continue
-            if not user_input:
-                continue
+    while True:
+        user_input = input("You: ").strip()
+        if user_input.lower() == "exit":
+            break
+        if user_input.lower() == "save":
+            await engine.save_conversation("conversation.json")
+            continue
+        if not user_input:
+            continue
 
-            result = await chat.think_and_respond(user_input)
-            print(f"\n🤖 AI FINAL RESPONSE: {result.response}\n")
-            print("\n--- COMPLETE THINKING PROCESS ---")
-            for item in result.thinking_history:
-                label = "[SELECTED]" if item.get("selected") else "[ALTERNATIVE]"
-                print(f"\nRound {item['round']} {label}:")
-                print(f"  Response: {item['response']}")
-                if item.get("explanation") and item.get("selected"):
-                    print(f"  Reason for selection: {item['explanation']}")
-                print("-" * 50)
-            print("--------------------------------\n")
+        result = await engine.think_and_respond(user_input)
+        print(f"\n🤖 AI FINAL RESPONSE: {result.response}\n")
+        print("\n--- COMPLETE THINKING PROCESS ---")
+        for item in result.thinking_history:
+            label = "[SELECTED]" if item.selected else "[ALTERNATIVE]"
+            print(f"\nRound {item.round_number} {label}:")
+            print(f"  Response: {item.response}")
+            if item.explanation and item.selected:
+                print(f"  Reason for selection: {item.explanation}")
+            print("-" * 50)
+        print("--------------------------------\n")
 
-        save_on_exit = (
-            input("Save conversation before exiting? (y/n): ").strip().lower()
-        )
-        if save_on_exit == "y":
-            await chat.save_conversation("conversation.json")
+    save_on_exit = input("Save conversation before exiting? (y/n): ").strip().lower()
+    if save_on_exit == "y":
+        await engine.save_conversation("conversation.json")
     print("Goodbye! 👋")
 
 

--- a/start-recthink.bat
+++ b/start-recthink.bat
@@ -7,7 +7,7 @@ pip install -r requirements.txt --no-cache-dir
 
 echo.
 echo [1/2] Starting Backend API Server...
-start cmd /k "python recthink_web.py"
+start cmd /k "python recthink_web_v2.py"
 
 echo [2/2] Starting Frontend Development Server...
 cd frontend


### PR DESCRIPTION
## Summary
- add new `recthink_web_v2.py` FastAPI app using chat_v2 engine
- update CLI to use the v2 engine
- reference the new server in README and start script

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: core.resilience.circuit_breaker, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684994e1d704833385764103e3a0f7f4