### PR TITLE
Add OpenAI provider

### DIFF
--- a/config/production.py
+++ b/config/production.py
@@ -77,6 +77,7 @@ class DatabaseSettings(BaseSettings):
 class LLMSettings(BaseSettings):
     """LLM provider settings."""
 
+    provider: str = Field("openrouter", env="LLM_PROVIDER")
     primary_provider: str = Field("openrouter", env="LLM_PRIMARY_PROVIDER")
     primary_model: str = Field(..., env="LLM_PRIMARY_MODEL")
     primary_api_key: SecretStr = Field(..., env="LLM_PRIMARY_API_KEY")

--- a/config/settings.py
+++ b/config/settings.py
@@ -4,7 +4,9 @@ from pydantic_settings import BaseSettings
 class Settings(BaseSettings):
     """Application settings loaded from environment variables."""
 
+    llm_provider: str = "openrouter"
     openrouter_api_key: str | None = None
+    openai_api_key: str | None = None
     model: str = "mistralai/mistral-small-3.1-24b-instruct:free"
     api_base_url: str = "https://openrouter.ai/api/v1/chat/completions"
     embed_url: str = "https://openrouter.ai/api/v1/embeddings"

--- a/core/chat_v2.py
+++ b/core/chat_v2.py
@@ -20,6 +20,7 @@ from core.context_manager import ContextManager
 from monitoring.metrics import MetricsRecorder
 from core.providers import (
     OpenRouterLLMProvider,
+    OpenAILLMProvider,
     InMemoryLRUCache,
     EnhancedQualityEvaluator,
 )
@@ -60,6 +61,7 @@ class CoRTConfig:
 
     api_key: str | None = field(default_factory=lambda: settings.openrouter_api_key)
     model: str = field(default_factory=lambda: settings.model)
+    provider: str = field(default_factory=lambda: settings.llm_provider)
     max_context_tokens: int = 2000
     cache_size: int = 128
     max_retries: int = 3
@@ -479,11 +481,18 @@ Respond in this JSON format:
 def create_default_engine(config: CoRTConfig) -> RecursiveThinkingEngine:
     """Convenience helper to build a thinking engine from a config."""
 
-    llm = OpenRouterLLMProvider(
-        api_key=config.api_key or os.getenv("OPENROUTER_API_KEY"),
-        model=config.model,
-        max_retries=config.max_retries,
-    )
+    if config.provider.lower() == "openai":
+        llm = OpenAILLMProvider(
+            api_key=config.api_key or os.getenv("OPENAI_API_KEY"),
+            model=config.model,
+            max_retries=config.max_retries,
+        )
+    else:
+        llm = OpenRouterLLMProvider(
+            api_key=config.api_key or os.getenv("OPENROUTER_API_KEY"),
+            model=config.model,
+            max_retries=config.max_retries,
+        )
 
     cache = InMemoryLRUCache(max_size=config.cache_size)
 

--- a/core/providers/__init__.py
+++ b/core/providers/__init__.py
@@ -19,6 +19,7 @@ from .llm import (
     StandardLLMResponse,
     LLMProvider,
     OpenRouterLLMProvider,
+    OpenAILLMProvider,
     MultiProviderLLM,
 )
 from .quality import EnhancedQualityEvaluator, SimpleQualityEvaluator
@@ -38,6 +39,7 @@ __all__ = [
     "StandardLLMResponse",
     "LLMProvider",
     "OpenRouterLLMProvider",
+    "OpenAILLMProvider",
     "MultiProviderLLM",
     "EnhancedQualityEvaluator",
     "SimpleQualityEvaluator",

--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -1,6 +1,11 @@
 import pytest
+import types
 
-from core.providers.llm import OpenRouterLLMProvider, StandardLLMResponse
+from core.providers.llm import (
+    OpenRouterLLMProvider,
+    OpenAILLMProvider,
+    StandardLLMResponse,
+)
 
 
 @pytest.mark.asyncio
@@ -10,6 +15,32 @@ async def test_llm_provider_chat(monkeypatch):
 
     monkeypatch.setattr("api.openrouter.async_chat_completion", fake_async)
     provider = OpenRouterLLMProvider(api_key="k", model="m")
+    async with provider as llm:
+        resp = await llm.chat([{"role": "user", "content": "hi"}])
+
+    assert isinstance(resp, StandardLLMResponse)
+    assert resp.content == "ok"
+    assert resp.model == "m"
+
+
+@pytest.mark.asyncio
+async def test_openai_llm_provider_chat(monkeypatch):
+    class FakeChatCompletions:
+        async def create(self, model, messages, temperature=0.7, max_tokens=None):
+            return types.SimpleNamespace(
+                choices=[types.SimpleNamespace(message=types.SimpleNamespace(content="ok"))],
+                usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            )
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            self.chat = types.SimpleNamespace(completions=FakeChatCompletions())
+
+        async def close(self):
+            pass
+
+    monkeypatch.setattr("core.providers.llm.openai.AsyncOpenAI", FakeClient)
+    provider = OpenAILLMProvider(api_key="k", model="m")
     async with provider as llm:
         resp = await llm.chat([{"role": "user", "content": "hi"}])
 


### PR DESCRIPTION
## Summary
- add OpenAI LLM provider alongside existing OpenRouter provider
- allow selecting provider via `llm_provider` config
- support provider choice in `create_default_engine`
- expose new provider from providers package
- test OpenAI provider behavior with mocked client

## Testing
- `flake8 core config tests`
- `PYTHONPATH=. pytest tests/test_llm_provider.py -q`
- `PYTHONPATH=. pytest -q` *(fails: HTTPSConnectionPool errors, AttributeError in chat engine, KeyError in metrics)*

------
https://chatgpt.com/codex/tasks/task_e_68499ee798648333a5e2b5d7e220a525